### PR TITLE
Use dependency groups in setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ The Autosubmit API have some configuration options that can be modified by setti
 ### Install pytest
 
 ```bash
-pip install -U pytest pytest-cov
+pip install -e .[test]
 ```
 
 ### Run tests:
 
 ```bash
-pytest tests/*
+pytest
 ```
 
 ### Run tests with coverage HTML report:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+addopts =
+    --cov=autosubmit_api --cov-config=.coveragerc --cov-report=html
+testpaths =
+    tests/
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
+    ELLIPSIS
+

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,40 @@ def get_authors():
     return autosubmit_api.__author__
 
 
+install_requires = [
+    "Flask~=2.2.5",
+    "pyjwt~=2.8.0",
+    "requests~=2.28.1",
+    "flask_cors~=3.0.10",
+    "bscearth.utils~=0.5.2",
+    "pysqlite-binary",
+    "pydotplus~=2.0.2",
+    "portalocker~=2.6.0",
+    "networkx~=2.6.3",
+    "scipy~=1.7.3",
+    "paramiko~=2.12.0",
+    "python-dotenv",
+    "autosubmitconfigparser~=1.0.48",
+    "autosubmit>=3.13",
+    "Flask-APScheduler",
+    "gunicorn",
+    "pydantic~=2.5.2",
+    "SQLAlchemy~=2.0.23",
+    "python-cas>=1.6.0",
+    "Authlib>=1.3.0"
+]
+
+# Test dependencies
+test_requires = [
+    "pytest",
+    "pytest-cov"
+]
+
+extras_require = {
+    'test': test_requires,
+    'all': install_requires + test_requires
+}
+
 setup(
     name="autosubmit_api",
     version=get_version(),
@@ -32,28 +66,8 @@ setup(
     packages=find_packages(),
     keywords=["autosubmit", "API"],
     python_requires=">=3.8",
-    install_requires=[
-        "Flask~=2.2.5",
-        "pyjwt~=2.8.0",
-        "requests~=2.28.1",
-        "flask_cors~=3.0.10",
-        "bscearth.utils~=0.5.2",
-        "pysqlite-binary",
-        "pydotplus~=2.0.2",
-        "portalocker~=2.6.0",
-        "networkx~=2.6.3",
-        "scipy~=1.7.3",
-        "paramiko~=2.12.0",
-        "python-dotenv",
-        "autosubmitconfigparser~=1.0.48",
-        "autosubmit>=3.13",
-        "Flask-APScheduler",
-        "gunicorn",
-        "pydantic~=2.5.2",
-        "SQLAlchemy~=2.0.23",
-        "python-cas>=1.6.0",
-        "Authlib>=1.3.0"
-    ],
+    install_requires=install_requires,
+    extras_require=extras_require,
     include_package_data=True,
     package_data={"autosubmit-api": ["README", "VERSION", "LICENSE"]},
     classifiers=[


### PR DESCRIPTION
In GitLab by @kinow on Feb 14, 2024, 12:47

Similar to what I did in autosubmitconfigparser. In the future we can move to `pyproject.toml`, and remove the setup.py, simplifying more the project configuration. But we can worry about that later, for now I think having autosubmitconfigpaser and the autosubmit_api with a similar setup, and both with pytest should be enough.