### PR TITLE
Refactor db_jobdata

### DIFF
--- a/autosubmit_api/autosubmit_legacy/job/job_list.py
+++ b/autosubmit_api/autosubmit_legacy/job/job_list.py
@@ -113,8 +113,7 @@ class JobList:
             chunk_size = experiment_run.chunk_size
         else:
             raise Exception("Autosubmit couldn't fin the experiment header information necessary to complete this request.")
-        job_list = job_data_structure.get_current_job_data(
-            run_id, all_states=True)
+        job_list = job_data_structure.get_current_job_data(run_id)
         if not job_list:
             return [], [], {}
         else:

--- a/autosubmit_api/database/common.py
+++ b/autosubmit_api/database/common.py
@@ -55,14 +55,19 @@ def create_main_db_conn() -> Connection:
     return builder.product
 
 
+def create_sqlite_db_engine(db_path: str) -> Engine:
+    """
+    Create an engine for a SQLite DDBB.
+    """
+    return create_engine(f"sqlite:///{ os.path.abspath(db_path)}", poolclass=NullPool)
+
+
 def create_autosubmit_db_engine() -> Engine:
     """
     Create an engine for the autosubmit DDBB. Usually named autosubmit.db
     """
     APIBasicConfig.read()
-    return create_engine(
-        f"sqlite:///{ os.path.abspath(APIBasicConfig.DB_PATH)}", poolclass=NullPool
-    )
+    return create_sqlite_db_engine(APIBasicConfig.DB_PATH)
 
 
 def create_as_times_db_engine() -> Engine:
@@ -71,7 +76,7 @@ def create_as_times_db_engine() -> Engine:
     """
     APIBasicConfig.read()
     db_path = os.path.join(APIBasicConfig.DB_DIR, APIBasicConfig.AS_TIMES_DB)
-    return create_engine(f"sqlite:///{ os.path.abspath(db_path)}", poolclass=NullPool)
+    return create_sqlite_db_engine(db_path)
 
 
 def execute_with_limit_offset(

--- a/autosubmit_api/database/tables.py
+++ b/autosubmit_api/database/tables.py
@@ -1,4 +1,13 @@
-from sqlalchemy import Column, MetaData, Integer, String, Text, Table
+from sqlalchemy import (
+    Column,
+    Float,
+    MetaData,
+    Integer,
+    String,
+    Text,
+    Table,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
 
 
@@ -106,3 +115,60 @@ graph_data_table: Table = GraphDataTable
 # Job package TABLES
 job_package_table: Table = JobPackageTable.__table__
 wrapper_job_package_table: Table = WrapperJobPackageTable.__table__
+
+ExperimentRunTable = Table(
+    "experiment_run",
+    metadata_obj,
+    Column("run_id", Integer, primary_key=True),
+    Column("created", Text, nullable=False),
+    Column("modified", Text, nullable=True),
+    Column("start", Integer, nullable=False),
+    Column("finish", Integer),
+    Column("chunk_unit", Text, nullable=False),
+    Column("chunk_size", Integer, nullable=False),
+    Column("completed", Integer, nullable=False),
+    Column("total", Integer, nullable=False),
+    Column("failed", Integer, nullable=False),
+    Column("queuing", Integer, nullable=False),
+    Column("running", Integer, nullable=False),
+    Column("submitted", Integer, nullable=False),
+    Column("suspended", Integer, nullable=False, default=0),
+    Column("metadata", Text),
+)
+
+JobDataTable = Table(
+    "job_data",
+    metadata_obj,
+    Column("id", Integer, nullable=False, primary_key=True),
+    Column("counter", Integer, nullable=False),
+    Column("job_name", Text, nullable=False, index=True),
+    Column("created", Text, nullable=False),
+    Column("modified", Text, nullable=False),
+    Column("submit", Integer, nullable=False),
+    Column("start", Integer, nullable=False),
+    Column("finish", Integer, nullable=False),
+    Column("status", Text, nullable=False),
+    Column("rowtype", Integer, nullable=False),
+    Column("ncpus", Integer, nullable=False),
+    Column("wallclock", Text, nullable=False),
+    Column("qos", Text, nullable=False),
+    Column("energy", Integer, nullable=False),
+    Column("date", Text, nullable=False),
+    Column("section", Text, nullable=False),
+    Column("member", Text, nullable=False),
+    Column("chunk", Integer, nullable=False),
+    Column("last", Integer, nullable=False),
+    Column("platform", Text, nullable=False),
+    Column("job_id", Integer, nullable=False),
+    Column("extra_data", Text, nullable=False),
+    Column("nnodes", Integer, nullable=False, default=0),
+    Column("run_id", Integer),
+    Column("MaxRSS", Float, nullable=False, default=0.0),
+    Column("AveRSS", Float, nullable=False, default=0.0),
+    Column("out", Text, nullable=False),
+    Column("err", Text, nullable=False),
+    Column("rowstatus", Integer, nullable=False, default=0),
+    Column("children", Text, nullable=True),
+    Column("platform_output", Text, nullable=True),
+    UniqueConstraint("counter", "job_name", name="unique_counter_and_job_name"),
+)

--- a/autosubmit_api/database/tables.py
+++ b/autosubmit_api/database/tables.py
@@ -1,4 +1,4 @@
-from sqlalchemy import MetaData, Integer, String, Text, Table
+from sqlalchemy import Column, MetaData, Integer, String, Text, Table
 from sqlalchemy.orm import DeclarativeBase, mapped_column, Mapped
 
 
@@ -52,18 +52,16 @@ class ExperimentStatusTable(BaseTable):
     modified: Mapped[str] = mapped_column(Text, nullable=False)
 
 
-class GraphDataTable(BaseTable):
-    """
-    Stores the coordinates and it is used exclusively to speed up the process
-    of generating the graph layout
-    """
-
-    __tablename__ = "experiment_graph_draw"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    job_name: Mapped[str] = mapped_column(Text, nullable=False)
-    x: Mapped[int] = mapped_column(Integer, nullable=False)
-    y: Mapped[int] = mapped_column(Integer, nullable=False)
+GraphDataTable = Table(
+    "experiment_graph_draw",
+    metadata_obj,
+    Column("id", Integer, primary_key=True),
+    Column("job_name", Text, nullable=False),
+    Column("x", Integer, nullable=False),
+    Column("y", Integer, nullable=False),
+)
+"""Stores the coordinates and it is used exclusively 
+to speed up the process of generating the graph layout"""
 
 
 class JobPackageTable(BaseTable):
@@ -103,7 +101,7 @@ details_table: Table = DetailsTable.__table__
 experiment_status_table: Table = ExperimentStatusTable.__table__
 
 # Graph Data TABLES
-graph_data_table: Table = GraphDataTable.__table__
+graph_data_table: Table = GraphDataTable
 
 # Job package TABLES
 job_package_table: Table = JobPackageTable.__table__

--- a/autosubmit_api/repositories/experiment.py
+++ b/autosubmit_api/repositories/experiment.py
@@ -1,0 +1,73 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from pydantic import BaseModel
+from sqlalchemy import Engine, Table
+from autosubmit_api.database import tables
+from autosubmit_api.database.common import create_autosubmit_db_engine
+
+
+class ExperimentModel(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    autosubmit_version: Optional[str] = None
+
+
+class ExperimentRepository(ABC):
+    @abstractmethod
+    def get_all(self) -> List[ExperimentModel]:
+        """
+        Get all the experiments
+
+        :return experiments: The list of experiments
+        """
+        pass
+
+    @abstractmethod
+    def get_by_expid(self, expid: str) -> ExperimentModel:
+        """
+        Get the experiment by expid
+
+        :param expid: The experiment id
+        :return experiment: The experiment
+        :raises ValueError: If the experiment is not found
+        """
+        pass
+
+
+class ExperimentSQLRepository(ExperimentRepository):
+    def __init__(self, engine: Engine, table: Table):
+        self.engine = engine
+        self.table = table
+
+    def get_all(self):
+        with self.engine.connect() as conn:
+            statement = self.table.select()
+            result = conn.execute(statement).all()
+        return [
+            ExperimentModel(
+                id=row.id,
+                name=row.name,
+                description=row.description,
+                autosubmit_version=row.autosubmit_version,
+            )
+            for row in result
+        ]
+
+    def get_by_expid(self, expid: str):
+        with self.engine.connect() as conn:
+            statement = self.table.select().where(self.table.c.name == expid)
+            result = conn.execute(statement).first()
+        if result is None:
+            raise ValueError(f"Experiment with id {expid} not found")
+        return ExperimentModel(
+            id=result.id,
+            name=result.name,
+            description=result.description,
+            autosubmit_version=result.autosubmit_version,
+        )
+
+
+def create_experiment_repository() -> ExperimentRepository:
+    engine = create_autosubmit_db_engine()
+    return ExperimentSQLRepository(engine, tables.experiment_table)

--- a/autosubmit_api/repositories/experiment_run.py
+++ b/autosubmit_api/repositories/experiment_run.py
@@ -1,0 +1,92 @@
+from abc import ABC, abstractmethod
+from typing import Any, List
+from pydantic import BaseModel
+from sqlalchemy import Engine, Table
+from sqlalchemy.schema import CreateTable
+from autosubmit_api.database import tables
+from autosubmit_api.database.common import create_sqlite_db_engine
+from autosubmit_api.persistance.experiment import ExperimentPaths
+
+
+class ExperimentRunModel(BaseModel):
+    run_id: Any
+    created: Any
+    modified: Any
+    start: Any
+    finish: Any
+    chunk_unit: Any
+    chunk_size: Any
+    completed: Any
+    total: Any
+    failed: Any
+    queuing: Any
+    running: Any
+    submitted: Any
+    suspended: Any
+    metadata: Any
+
+
+class ExperimentRunRepository(ABC):
+    @abstractmethod
+    def get_all(self) -> List[ExperimentRunModel]:
+        """
+        Gets all runs of the experiment
+        """
+
+    @abstractmethod
+    def get_last_run(self) -> ExperimentRunModel:
+        """
+        Gets last run of the experiment. Raises ValueError if no runs found.
+        """
+
+    @abstractmethod
+    def get_run_by_id(self, run_id: int) -> ExperimentRunModel:
+        """
+        Gets run by id. Raises ValueError if run not found.
+        """
+
+
+class ExperimentRunSQLRepository(ExperimentRunRepository):
+    def __init__(self, expid: str, engine: Engine, table: Table):
+        self.engine = engine
+        self.table = table
+        self.expid = expid
+
+        with self.engine.connect() as conn:
+            conn.execute(CreateTable(self.table, if_not_exists=True))
+            conn.commit()
+
+    def get_all(self):
+        with self.engine.connect() as conn:
+            statement = self.table.select()
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentRunModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+    def get_last_run(self):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select().order_by(self.table.c.run_id.desc())
+            )
+            result = conn.execute(statement).first()
+        if result is None:
+            raise ValueError(f"No runs found for experiment {self.expid}")
+        return ExperimentRunModel.model_validate(result, from_attributes=True)
+
+    def get_run_by_id(self, run_id: int):
+        with self.engine.connect() as conn:
+            statement = self.table.select().where(self.table.c.run_id == run_id)
+            result = conn.execute(statement).first()
+        if result is None:
+            raise ValueError(
+                f"Run with id {run_id} not found for experiment {self.expid}"
+            )
+        return ExperimentRunModel.model_validate(result, from_attributes=True)
+
+
+def create_experiment_run_repository(expid: str):
+    engine = create_sqlite_db_engine(ExperimentPaths(expid).job_data_db)
+    return ExperimentRunSQLRepository(expid, engine, tables.ExperimentRunTable)

--- a/autosubmit_api/repositories/graph_layout.py
+++ b/autosubmit_api/repositories/graph_layout.py
@@ -1,0 +1,72 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Union
+from pydantic import BaseModel
+from sqlalchemy import Engine, Table
+from sqlalchemy.schema import CreateTable
+from autosubmit_api.database import tables
+from autosubmit_api.database.common import create_sqlite_db_engine
+from autosubmit_api.persistance.experiment import ExperimentPaths
+
+
+class ExpGraphLayoutModel(BaseModel):
+    id: Union[int, Any]
+    job_name: Union[str, Any]
+    x: Union[float, Any]
+    y: Union[float, Any]
+
+
+class ExpGraphLayoutRepository(ABC):
+    @abstractmethod
+    def get_all(self) -> List[ExpGraphLayoutModel]:
+        """
+        Get all the graph layout data.
+        """
+
+    def delete_all(self) -> int:
+        """
+        Delete all the graph layout data.
+        """
+
+    def insert_many(self, values: List[Dict[str, Any]]) -> int:
+        """
+        Insert many graph layout data.
+        """
+
+
+class ExpGraphLayoutSQLRepository(ExpGraphLayoutRepository):
+    def __init__(self, expid: str, engine: Engine, table: Table):
+        self.expid = expid
+        self.engine = engine
+        self.table = table
+
+        with self.engine.connect() as conn:
+            conn.execute(CreateTable(self.table, if_not_exists=True))
+            conn.commit()
+
+    def get_all(self) -> List[ExpGraphLayoutModel]:
+        with self.engine.connect() as conn:
+            statement = self.table.select()
+            result = conn.execute(statement).all()
+        return [
+            ExpGraphLayoutModel(id=row.id, job_name=row.job_name, x=row.x, y=row.y)
+            for row in result
+        ]
+
+    def delete_all(self) -> int:
+        with self.engine.connect() as conn:
+            statement = self.table.delete()
+            result = conn.execute(statement)
+            conn.commit()
+        return result.rowcount
+
+    def insert_many(self, values) -> int:
+        with self.engine.connect() as conn:
+            statement = self.table.insert()
+            result = conn.execute(statement, values)
+            conn.commit()
+        return result.rowcount
+
+
+def create_exp_graph_layout_repository(expid: str) -> ExpGraphLayoutRepository:
+    engine = create_sqlite_db_engine(ExperimentPaths(expid).graph_data_db)
+    return ExpGraphLayoutSQLRepository(expid, engine, tables.GraphDataTable)

--- a/autosubmit_api/repositories/job_data.py
+++ b/autosubmit_api/repositories/job_data.py
@@ -1,0 +1,194 @@
+from abc import ABC, abstractmethod
+from typing import Any, List
+from pydantic import BaseModel
+from sqlalchemy import Engine, Table, or_, Index
+from sqlalchemy.schema import CreateTable
+from autosubmit_api.database import tables
+from autosubmit_api.database.common import create_sqlite_db_engine
+from autosubmit_api.persistance.experiment import ExperimentPaths
+
+
+class ExperimentJobDataModel(BaseModel):
+    id: Any
+    counter: Any
+    job_name: Any
+    created: Any
+    modified: Any
+    submit: Any
+    start: Any
+    finish: Any
+    status: Any
+    rowtype: Any
+    ncpus: Any
+    wallclock: Any
+    qos: Any
+    energy: Any
+    date: Any
+    section: Any
+    member: Any
+    chunk: Any
+    last: Any
+    platform: Any
+    job_id: Any
+    extra_data: Any
+    nnodes: Any
+    run_id: Any
+    MaxRSS: Any
+    AveRSS: Any
+    out: Any
+    err: Any
+    rowstatus: Any
+    children: Any
+
+
+class ExperimentJobDataRepository(ABC):
+    @abstractmethod
+    def get_last_job_data_by_run_id(self, run_id: int) -> List[ExperimentJobDataModel]:
+        """
+        Gets last job data of an specific run id
+        """
+
+    @abstractmethod
+    def get_last_job_data(self) -> List[ExperimentJobDataModel]:
+        """
+        Gets last job data
+        """
+
+    @abstractmethod
+    def get_jobs_by_name(self, job_name: str) -> List[ExperimentJobDataModel]:
+        """
+        Gets historical job data by job_name
+        """
+
+    @abstractmethod
+    def get_all(self) -> List[ExperimentJobDataModel]:
+        """
+        Gets all job data
+        """
+
+    @abstractmethod
+    def get_job_data_COMPLETED_by_rowtype_run_id(
+        self, rowtype: int, run_id: int
+    ) -> List[ExperimentJobDataModel]:
+        """
+        Gets job data by rowtype and run id
+        """
+
+    @abstractmethod
+    def get_job_data_COMPLETD_by_section(
+        self, section: str
+    ) -> List[ExperimentJobDataModel]:
+        """
+        Gets job data by section
+        """
+
+
+class ExperimentJobDataSQLRepository(ExperimentJobDataRepository):
+    def __init__(self, expid: str, engine: Engine, table: Table):
+        self.engine = engine
+        self.table = table
+        self.expid = expid
+
+        with self.engine.connect() as conn:
+            conn.execute(CreateTable(self.table, if_not_exists=True))
+            Index("ID_JOB_NAME", self.table.c.job_name).create(conn, checkfirst=True)
+            conn.commit()
+
+    def get_last_job_data_by_run_id(self, run_id: int):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select()
+                .where(
+                    (self.table.c.run_id == run_id),
+                    (self.table.c.rowtype >= 2),
+                )
+                .order_by(self.table.c.id.desc())
+            )
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentJobDataModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+    def get_last_job_data(self):
+        with self.engine.connect() as conn:
+            statement = self.table.select().where(
+                (self.table.c.last == 1),
+                (self.table.c.rowtype >= 2),
+            )
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentJobDataModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+    def get_jobs_by_name(self, job_name: str):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select()
+                .where(self.table.c.job_name == job_name)
+                .order_by(self.table.c.counter.desc())
+            )
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentJobDataModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+    def get_all(self):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select().where(self.table.c.id > 0).order_by(self.table.c.id)
+            )
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentJobDataModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+    def get_job_data_COMPLETED_by_rowtype_run_id(self, rowtype: int, run_id: int):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select()
+                .where(
+                    (self.table.c.rowtype == rowtype),
+                    (self.table.c.run_id == run_id),
+                    (self.table.c.status == "COMPLETED"),
+                )
+                .order_by(self.table.c.id)
+            )
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentJobDataModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+    def get_job_data_COMPLETD_by_section(self, section: str):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select()
+                .where(
+                    (self.table.c.status == "COMPLETED"),
+                    or_(
+                        (self.table.c.section == section),
+                        (self.table.c.member == section),
+                    ),
+                )
+                .order_by(self.table.c.id)
+            )
+            result = conn.execute(statement).all()
+
+        return [
+            ExperimentJobDataModel.model_validate(row, from_attributes=True)
+            for row in result
+        ]
+
+
+def create_experiment_job_data_repository(expid: str):
+    engine = create_sqlite_db_engine(ExperimentPaths(expid).job_data_db)
+    return ExperimentJobDataSQLRepository(expid, engine, tables.JobDataTable)

--- a/tests/test_jobdata.py
+++ b/tests/test_jobdata.py
@@ -1,0 +1,36 @@
+from autosubmit_api.database.db_jobdata import JobDataStructure, ExperimentRun
+
+
+class TestJobDataStructure:
+    def test_valid_operations(self, fixture_mock_basic_config):
+        expid = "a003"
+        job_data_db = JobDataStructure(expid, None)
+
+        last_exp_run = job_data_db.get_max_id_experiment_run()
+
+        assert isinstance(last_exp_run, ExperimentRun)
+        assert last_exp_run.run_id == 3
+        assert last_exp_run.total == 8
+
+        exp_run = job_data_db.get_experiment_run_by_id(2)
+        assert isinstance(exp_run, ExperimentRun)
+        assert exp_run.run_id == 2
+        assert exp_run.total == 8
+
+        # Run greater that the last one
+        exp_run = job_data_db.get_experiment_run_by_id(4)
+        assert exp_run is None
+
+        job_data = job_data_db.get_current_job_data(3)
+        assert isinstance(job_data, list)
+        assert len(job_data) == 8
+
+    def test_invalid_operations(self, fixture_mock_basic_config):
+        expid = "404"
+        job_data_db = JobDataStructure(expid, None)
+
+        last_exp_run = job_data_db.get_max_id_experiment_run()
+        assert last_exp_run is None
+
+        exp_run = job_data_db.get_experiment_run_by_id(2)
+        assert exp_run is None

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,4 +1,6 @@
+from sqlalchemy import inspect
 from autosubmit_api.repositories.experiment import create_experiment_repository
+from autosubmit_api.repositories.job_data import create_experiment_job_data_repository
 from autosubmit_api.repositories.graph_layout import create_exp_graph_layout_repository
 
 
@@ -45,3 +47,15 @@ class TestExpGraphLayoutRepository:
         # Table is empty
         graph_data = [x.model_dump() for x in graph_draw_db.get_all()]
         assert graph_data == []
+
+
+class TestExperimentJobDataRepository:
+    def test_sql_init(self, fixture_mock_basic_config):
+        exp_run_repository = create_experiment_job_data_repository("any")
+
+        # Check if index exists and is correct
+        inspector = inspect(exp_run_repository.engine)
+        indexes = inspector.get_indexes(exp_run_repository.table.name)
+        assert len(indexes) == 1
+        assert indexes[0]["name"] == "ID_JOB_NAME"
+        assert indexes[0]["column_names"] == ["job_name"]

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,47 @@
+from autosubmit_api.repositories.experiment import create_experiment_repository
+from autosubmit_api.repositories.graph_layout import create_exp_graph_layout_repository
+
+
+class TestExperimentRepository:
+    def test_operations(self, fixture_mock_basic_config):
+        experiment_db = create_experiment_repository()
+
+        EXPIDS = ["a003", "a007", "a3tb", "a6zj"]
+
+        # Check get_all
+        rows = experiment_db.get_all()
+        assert len(rows) >= 4
+        for expid in EXPIDS:
+            assert expid in [row.name for row in rows]
+
+        # Check get_by_expid
+        for expid in EXPIDS:
+            row = experiment_db.get_by_expid(expid)
+            assert row.name == expid
+
+
+class TestExpGraphLayoutRepository:
+    def test_operations(self, fixture_mock_basic_config):
+        expid = "g001"
+        graph_draw_db = create_exp_graph_layout_repository(expid)
+
+        # Table exists and is empty
+        assert graph_draw_db.get_all() == []
+
+        # Insert data
+        data = [
+            {"id": 1, "job_name": "job1", "x": 1, "y": 2},
+            {"id": 2, "job_name": "job2", "x": 2, "y": 3},
+        ]
+        assert graph_draw_db.insert_many(data) == len(data)
+
+        # Get data
+        graph_data = [x.model_dump() for x in graph_draw_db.get_all()]
+        assert graph_data == data
+
+        # Delete data
+        assert graph_draw_db.delete_all() == len(data)
+
+        # Table is empty
+        graph_data = [x.model_dump() for x in graph_draw_db.get_all()]
+        assert graph_data == []


### PR DESCRIPTION
In GitLab by @LuiggiTenorioK on Nov 6, 2024, 16:32

In order to centralize the db managers as it is done in the Postgres branch we need to refactor the job_data module

Also, this solves the last issue we have with #73 where the graph data DB file is kept open when it is executed.