### PR TITLE
Make /v3/expinfo endpoint not blocking

### DIFF
--- a/tests/test_common_requests.py
+++ b/tests/test_common_requests.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+from autosubmit_api.experiment.common_requests import get_experiment_data
+
+
+class TestGetExperimentData:
+    def test_valid(self, fixture_mock_basic_config):
+        expid = "a1ve"
+        result = get_experiment_data(expid)
+
+        assert result.get("expid") == expid
+        assert result.get("description") == "networkx pkl"
+        assert result.get("total_jobs") == 8
+        assert result.get("completed_jobs") == 8
+        assert result.get("path") != "NA"
+        assert len(result.get("time_last_access")) > 0
+
+    def test_fail_as_conf(self, fixture_mock_basic_config):
+        """
+        When experiment is archived, the AutosubmitConfigurationFacadeBuilder will raise
+        an exception because the experiment directory is not found.
+        """
+        expid = "a1ve"
+
+        with patch(
+            "autosubmit_api.experiment.common_requests.AutosubmitConfigurationFacadeBuilder"
+        ) as mock:
+            mock.side_effect = Exception("AutosubmitConfig failed")
+            result = get_experiment_data(expid)
+
+            assert result.get("expid") == expid
+            assert result.get("description") == "networkx pkl"
+            assert result.get("total_jobs") == 8
+            assert result.get("completed_jobs") == 8
+
+            # Failed ones giving default values
+            assert result.get("path") == "NA"
+            assert len(result.get("time_last_access")) == 0
+
+    def test_dbs_missing(self, fixture_mock_basic_config):
+        expid = "a1ve"
+
+        with patch(
+            "autosubmit_api.experiment.common_requests.create_experiment_repository"
+        ) as exp_repo_mock, patch(
+            "autosubmit_api.experiment.common_requests.DbRequests"
+        ) as dbrequests_mock, patch(
+            "autosubmit_api.experiment.common_requests.ExperimentHistoryBuilder"
+        ) as history_mock:
+            exp_repo_mock.side_effect = Exception("Experiment repository failed")
+            dbrequests_mock.get_specific_experiment_status.side_effect = Exception(
+                "Experiment status failed"
+            )
+            history_mock.side_effect = Exception("Experiment history failed")
+
+            result = get_experiment_data(expid)
+
+            # Successful ones
+            assert result.get("expid") == expid
+            assert result.get("path") != "NA"
+            assert len(result.get("time_last_access")) > 0
+
+            # Failed ones giving default values
+            assert result.get("description") == ""
+            assert result.get("total_jobs") == 0
+            assert result.get("completed_jobs") == 0


### PR DESCRIPTION
PR to allow the `/v3/expinfo/{expid}` endpoint to get all the information it can get from the experiment. 

Currently, it happens that when an experiment is archived the config reading process fails and other data is not retrieved like the ones in the DBs. This has been reported in https://github.com/BSC-ES/autosubmit-gui/issues/225 and the idea is that this endpoint **should still return the description and version (and other things like status and total/completed jobs from the DBs)**.

Having this data can give us an idea of whether the experiment **may** be archived or not. With this change, the rule to guess if the experiment is archived will be as follows: 

**_The experiment has a description and version but doesn't have last access and modified time_**

This implies that the experiment is in DB but the directory is missing (or maybe inaccessible) which is most likely due to an `autosubmit archive`.