### PR TITLE
Enforce ISO 8601 for timestamps convertion

### DIFF
--- a/autosubmit_api/common/utils.py
+++ b/autosubmit_api/common/utils.py
@@ -191,11 +191,18 @@ def get_experiments_from_folder(root_folder: str) -> List[str]:
   folders = stdOut.split()      
   return [expid for expid in folders if len(expid) == 4]
 
+
+def get_local_tz():
+  return datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+
+
 def timestamp_to_datetime_format(timestamp: int) -> str:
-  """ %Y-%m-%d %H:%M:%S """
+  """
+  Formats a timestamp to a iso format datetime string with timezone information.
+  """
   try:
     if timestamp and timestamp > 0:
-      return datetime.datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
+      return datetime.datetime.fromtimestamp(timestamp, tz=get_local_tz()).isoformat()
   except Exception as exp:    
     print(("Timestamp {} cannot be converted to datetime string. {}".format(str(timestamp), str(exp))))
     return None

--- a/autosubmit_api/common/utils.py
+++ b/autosubmit_api/common/utils.py
@@ -9,6 +9,8 @@ from bscearth.utils.date import date2str
 from dateutil.relativedelta import relativedelta
 from typing import List, Tuple
 
+LOCAL_TZ = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+
 class Section:
   CONFIG = "CONFIG"
   MAIL = "MAIL"
@@ -191,18 +193,13 @@ def get_experiments_from_folder(root_folder: str) -> List[str]:
   folders = stdOut.split()      
   return [expid for expid in folders if len(expid) == 4]
 
-
-def get_local_tz():
-  return datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
-
-
 def timestamp_to_datetime_format(timestamp: int) -> str:
   """
   Formats a timestamp to a iso format datetime string with timezone information.
   """
   try:
     if timestamp and timestamp > 0:
-      return datetime.datetime.fromtimestamp(timestamp, tz=get_local_tz()).isoformat()
+      return datetime.datetime.fromtimestamp(timestamp, tz=LOCAL_TZ).isoformat()
   except Exception as exp:    
     print(("Timestamp {} cannot be converted to datetime string. {}".format(str(timestamp), str(exp))))
     return None

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -61,5 +61,5 @@ def test_timestamp_to_datetime_format(
     timestamp: int, expected: Union[str, None], timezone: str
 ):
     mock_tzinfo = ZoneInfo(timezone)
-    with patch("autosubmit_api.common.utils.get_local_tz", return_value=mock_tzinfo):
+    with patch("autosubmit_api.common.utils.LOCAL_TZ", mock_tzinfo):
         assert timestamp_to_datetime_format(timestamp) == expected

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,10 @@
-from typing import List
+from typing import List, Union
+from unittest.mock import patch
 import pytest
 from autosubmit_api.common import utils
 from autosubmit_api.components.jobs.job_factory import SimJob
+from autosubmit_api.common.utils import timestamp_to_datetime_format
+from zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(
@@ -39,3 +42,24 @@ def test_outlier_detection(
 
     assert len(valid_jobs) == len(valid_run_times)
     assert len(outliers) == (len(outlier_run_times) + zeros)
+
+
+@pytest.mark.parametrize(
+    "timestamp, expected, timezone",
+    [
+        (1633072800, "2021-10-01T07:20:00+00:00", "UTC"),  # Valid timestamp
+        (0, None, "UTC"),  # Invalid timestamp (0)
+        (-1, None, "UTC"),  # Invalid timestamp (negative)
+        (None, None, "UTC"),  # None timestamp
+        (1633072800.0, "2021-10-01T07:20:00+00:00", "UTC"),  # Valid timestamp as float
+        (1736208000, "2025-01-07T00:00:00+00:00", "UTC"),
+        (1633072800, "2021-10-01T02:20:00-05:00", "America/Lima"),  # Other timezone
+        (1633072800, "2021-10-01T05:20:00-02:00", "Etc/GMT+2"),
+    ],
+)
+def test_timestamp_to_datetime_format(
+    timestamp: int, expected: Union[str, None], timezone: str
+):
+    mock_tzinfo = ZoneInfo(timezone)
+    with patch("autosubmit_api.common.utils.get_local_tz", return_value=mock_tzinfo):
+        assert timestamp_to_datetime_format(timestamp) == expected


### PR DESCRIPTION
PR to enable the API to correctly format the timestamps following the ISO 8601.

Related issue: https://github.com/BSC-ES/autosubmit-gui/issues/226

How it will show in the GUI:

![image](https://github.com/user-attachments/assets/5b175c9d-0434-48e8-ab20-ebe74298f747)
