### PR TITLE
Add config facade lazy load and separate /v3/expinfo file metadata retrieval

### DIFF
--- a/autosubmit_api/components/experiment/file_metadata.py
+++ b/autosubmit_api/components/experiment/file_metadata.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+from typing import Union
+
+from autosubmit_api.common.utils import timestamp_to_datetime_format
+
+
+class FileMetadata:
+    def __init__(self, path: Union[str, Path]):
+        self.path = Path(path)
+        self.stat = self.path.stat()
+
+    @property
+    def owner_id(self) -> int:
+        return int(self.stat.st_uid)
+
+    @property
+    def owner_name(self) -> str:
+        try:
+            stdout = os.popen("id -nu {0}".format(str(self.owner_id)))
+            owner_name = stdout.read().strip()
+            return str(owner_name)
+        except Exception:
+            raise Exception("Error while getting owner name")
+
+    @property
+    def access_time(self) -> str:
+        return timestamp_to_datetime_format(int(self.stat.st_atime))
+
+    @property
+    def modified_time(self) -> str:
+        return timestamp_to_datetime_format(int(self.stat.st_mtime))
+
+    @property
+    def created_time(self) -> str:
+        return timestamp_to_datetime_format(int(self.stat.st_ctime))

--- a/tests/test_common_requests.py
+++ b/tests/test_common_requests.py
@@ -27,14 +27,18 @@ class TestGetExperimentData:
             mock.side_effect = Exception("AutosubmitConfig failed")
             result = get_experiment_data(expid)
 
+            # Successful ones
             assert result.get("expid") == expid
             assert result.get("description") == "networkx pkl"
             assert result.get("total_jobs") == 8
             assert result.get("completed_jobs") == 8
+            assert result.get("path") != "NA"
+            assert len(result.get("time_last_access")) > 0
 
             # Failed ones giving default values
-            assert result.get("path") == "NA"
-            assert len(result.get("time_last_access")) == 0
+            assert result.get("hpc") == ""
+            assert result.get("chunk_size") == 0
+            assert result.get("chunk_unit") == "default"
 
     def test_dbs_missing(self, fixture_mock_basic_config):
         expid = "a1ve"
@@ -58,6 +62,9 @@ class TestGetExperimentData:
             assert result.get("expid") == expid
             assert result.get("path") != "NA"
             assert len(result.get("time_last_access")) > 0
+            assert result.get("hpc") == "LOCAL"
+            assert result.get("chunk_size") == 4
+            assert result.get("chunk_unit") == "month"
 
             # Failed ones giving default values
             assert result.get("description") == ""

--- a/tests/test_configuration_facade.py
+++ b/tests/test_configuration_facade.py
@@ -1,0 +1,105 @@
+from typing import Any, Dict
+import pytest
+from autosubmit_api.builders.configuration_facade_builder import (
+    AutosubmitConfigurationFacadeBuilder,
+    ConfigurationFacadeDirector,
+)
+
+
+@pytest.mark.parametrize(
+    "expid, expected, expected_method_results",
+    [
+        (
+            "a003",
+            {
+                "chunk_unit": "month",
+                "chunk_size": 4,
+                "current_years_per_sim": 1 / 3,
+                "sim_processors": 16,
+                "sim_tasks": None,
+                "sim_nodes": None,
+                "sim_processors_per_node": None,
+                "sim_exclusive": False,
+            },
+            {
+                "version": "4.0.0",
+                "main_platform": "LOCAL",
+                "model": "NA",
+                "branch": "NA",
+            },
+        ),
+        (
+            "a3tb",
+            {
+                "chunk_unit": "month",
+                "chunk_size": 1,
+                "current_years_per_sim": 1 / 12,
+                "sim_processors": 768,
+                "sim_tasks": None,
+                "sim_nodes": None,
+                "sim_processors_per_node": None,
+                "sim_exclusive": False,
+            },
+            {
+                "version": "3.13.0",
+                "main_platform": "marenostrum4",
+                "model": "https://earth.bsc.es/gitlab/es/auto-ecearth3.git",
+                "branch": "trunk",
+            },
+        ),
+        (
+            "a007",
+            {
+                "chunk_unit": "month",
+                "chunk_size": 4,
+                "current_years_per_sim": 1 / 3,
+                "sim_processors": 8,
+                "sim_tasks": None,
+                "sim_nodes": None,
+                "sim_processors_per_node": None,
+                "sim_exclusive": True,
+            },
+            {
+                "version": "4.0.95",
+                "main_platform": "LOCAL",
+                "model": "NA",
+                "branch": "NA",
+            },
+        ),
+    ],
+)
+def test_configuration_facade(
+    fixture_mock_basic_config,
+    expid: str,
+    expected: Dict[str, Any],
+    expected_method_results: Dict[str, Any],
+):
+    autosubmit_config_facade = ConfigurationFacadeDirector(
+        AutosubmitConfigurationFacadeBuilder(expid)
+    ).build_autosubmit_configuration_facade()
+
+    assert autosubmit_config_facade.expid == expid
+
+    # Assert properties
+    assert {
+        "chunk_unit": autosubmit_config_facade.chunk_unit,
+        "chunk_size": autosubmit_config_facade.chunk_size,
+        "current_years_per_sim": autosubmit_config_facade.current_years_per_sim,
+        "sim_processors": autosubmit_config_facade.sim_processors,
+        "sim_tasks": autosubmit_config_facade.sim_tasks,
+        "sim_nodes": autosubmit_config_facade.sim_nodes,
+        "sim_processors_per_node": autosubmit_config_facade.sim_processors_per_node,
+        "sim_exclusive": autosubmit_config_facade.sim_exclusive,
+    } == expected
+
+    # Assert methods
+    assert (
+        autosubmit_config_facade.get_autosubmit_version()
+        == expected_method_results["version"]
+    )
+    assert (
+        autosubmit_config_facade.get_main_platform()
+        == expected_method_results["main_platform"]
+    )
+    assert autosubmit_config_facade.get_model() == expected_method_results["model"]
+    assert autosubmit_config_facade.get_branch() == expected_method_results["branch"]

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,94 @@
+from typing import Any, Dict
+import pytest
+
+from autosubmit_api.builders.joblist_helper_builder import (
+    JobListHelperBuilder,
+    JobListHelperDirector,
+)
+from autosubmit_api.performance.performance_metrics import PerformanceMetrics
+
+
+@pytest.mark.parametrize(
+    "expid, expected, counters",
+    [
+        (
+            "a003",
+            {
+                "total_sim_run_time": 0,
+                "total_sim_queue_time": 0,
+                "SYPD": 0,
+                "ASYPD": 0,
+                "CHSY": 0,
+                "JPSY": 0,
+                "RSYPD": 0,
+                "processing_elements": 16,
+                "sim_processors": 16,
+                "post_jobs_total_time_average": 0.0,
+            },
+            {"considered_jobs_count": 0, "not_considered_jobs_count": 0},
+        ),
+        (
+            "a3tb",
+            {
+                "ASYPD": 12.9109,
+                "CHSY": 1167.36,
+                "JPSY": 57300000.0,
+                "RSYPD": 0,
+                "SYPD": 15.7895,
+                "post_jobs_total_time_average": 0.0,
+                "processing_elements": 768,
+                "sim_processors": 768,
+                "total_sim_queue_time": 610,
+                "total_sim_run_time": 2736,
+            },
+            {"considered_jobs_count": 6, "not_considered_jobs_count": 0},
+        ),
+        (
+            "a007",
+            {
+                "ASYPD": 3840.0,
+                "CHSY": 0.03,
+                "JPSY": 0,
+                "RSYPD": 1066.6667,
+                "SYPD": 5760.0,
+                "post_jobs_total_time_average": 5.0,
+                "processing_elements": 8,
+                "sim_processors": 8,
+                "total_sim_queue_time": 0,
+                "total_sim_run_time": 10,
+            },
+            {"considered_jobs_count": 2, "not_considered_jobs_count": 0},
+        ),
+    ],
+)
+def test_performance_metrics(
+    fixture_mock_basic_config,
+    expid: str,
+    expected: Dict[str, Any],
+    counters: Dict[str, Any],
+):
+    performance_metrics = PerformanceMetrics(
+        expid,
+        JobListHelperDirector(JobListHelperBuilder(expid)).build_job_list_helper(),
+    )
+
+    # Assert properties
+    assert {
+        "total_sim_run_time": performance_metrics.total_sim_run_time,
+        "total_sim_queue_time": performance_metrics.total_sim_queue_time,
+        "SYPD": performance_metrics.SYPD,
+        "ASYPD": performance_metrics.ASYPD,
+        "CHSY": performance_metrics.CHSY,
+        "JPSY": performance_metrics.JPSY,
+        "RSYPD": performance_metrics.RSYPD,
+        "processing_elements": performance_metrics.processing_elements,
+        "sim_processors": performance_metrics._sim_processors,
+        "post_jobs_total_time_average": performance_metrics.post_jobs_total_time_average,
+    } == expected
+
+    # Assert considered jobs count
+    assert len(performance_metrics._considered) == counters["considered_jobs_count"]
+    assert (
+        len(performance_metrics._not_considered)
+        == counters["not_considered_jobs_count"]
+    )


### PR DESCRIPTION
As discussed in https://github.com/BSC-ES/autosubmit-gui/issues/237, this PR makes the `/v3/expinfo` endpoint not block when failing in the config parsing avoiding doing unnecessary operations and separating the file stat phase.

The changes include:

- Separating the retrieval of the file metadata from the config parsing
- Make the `__init__` of the `AutosubmitConfigurationFacade` to not read the `JOBS.SIM` section. Instead, do it when it is needed and save the result for future calls (lazy loading).
- Tests to ensure it works as before the changes