### PR TITLE
Add autosubmit create job list to runners

### DIFF
--- a/autosubmit_api/routers/v4alpha/__init__.py
+++ b/autosubmit_api/routers/v4alpha/__init__.py
@@ -210,6 +210,8 @@ async def get_experiment_runner_status(expid: str):
 
 class CreateJobListBody(GetRunnerBody):
     check_wrapper: Optional[bool] = None
+    update_version: Optional[bool] = None
+    force: Optional[bool] = None
 
 
 @router.post("/experiments/{expid}/create-job-list", name="Create job list")
@@ -233,7 +235,12 @@ async def create_job_list(expid: str, body: CreateJobListBody):
             body.module_loader, body.modules
         )
         runner = get_runner(body.runner, module_loader)
-        await runner.create_job_list(expid, bool(body.check_wrapper))
+        await runner.create_job_list(
+            expid,
+            check_wrapper=body.check_wrapper,
+            update_version=body.update_version,
+            force=body.force,
+        )
     except Exception as exc:
         raise HTTPException(
             status_code=500,

--- a/autosubmit_api/runners/base.py
+++ b/autosubmit_api/runners/base.py
@@ -56,3 +56,11 @@ class Runner(ABC):
         :param expid: The experiment ID to stop.
         :param force: Whether to force stop the experiment.
         """
+
+    @abstractmethod
+    async def create_job_list(self, expid: str):
+        """
+        Create a job list for the given expid using `autosubmit create` command.
+
+        :param expid: The expid of the experiment to create a job list for.
+        """

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -231,6 +231,6 @@ class LocalRunner(Runner):
             ).strip()
             logger.debug(f"Command output: {output}")
             return output
-        except subprocess.CalledProcessError as exc:
+        except Exception as exc:
             logger.error(f"Command failed with error: {exc}")
             raise exc

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -219,6 +219,8 @@ class LocalRunner(Runner):
         This method will use a module loader to prepare the environment and run the command.
 
         :param expid: The experiment ID to create the job list for.
+        :param check_wrapper: If True, the command will check the wrapper script. Default is False.
+        :return: The output of the command.
         """
         flags = "--check-wrapper" if check_wrapper else ""
         autosubmit_command = f"autosubmit create -np {flags} {expid}"

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -213,7 +213,13 @@ class LocalRunner(Runner):
             status="STOPPED",
         )
 
-    async def create_job_list(self, expid: str, check_wrapper: bool = False):
+    async def create_job_list(
+        self,
+        expid: str,
+        check_wrapper: bool = False,
+        update_version: bool = False,
+        force: bool = False,
+    ) -> str:
         """
         Create a job list for the given expid using `autosubmit create` command.
         This method will use a module loader to prepare the environment and run the command.
@@ -222,8 +228,15 @@ class LocalRunner(Runner):
         :param check_wrapper: If True, the command will check the wrapper script. Default is False.
         :return: The output of the command.
         """
-        flags = "--check-wrapper" if check_wrapper else ""
-        autosubmit_command = f"autosubmit create -np {flags} {expid}"
+        flags = []
+        if check_wrapper:
+            flags.append("--check-wrapper")
+        if update_version:
+            flags.append("--update_version")
+        if force:
+            flags.append("--force")
+
+        autosubmit_command = f"autosubmit create -np {' '.join(flags)} {expid}"
         wrapped_command = self.module_loader.generate_command(autosubmit_command)
 
         try:

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -212,3 +212,25 @@ class LocalRunner(Runner):
             id=active_procs[0].id,
             status="STOPPED",
         )
+
+    async def create_job_list(self, expid: str, check_wrapper: bool = False):
+        """
+        Create a job list for the given expid using `autosubmit create` command.
+        This method will use a module loader to prepare the environment and run the command.
+
+        :param expid: The experiment ID to create the job list for.
+        """
+        flags = "--check-wrapper" if check_wrapper else ""
+        autosubmit_command = f"autosubmit create -np {flags} {expid}"
+        wrapped_command = self.module_loader.generate_command(autosubmit_command)
+
+        try:
+            logger.debug(f"Running command: {wrapped_command}")
+            output = subprocess.check_output(
+                wrapped_command, shell=True, text=True, executable="/bin/bash"
+            ).strip()
+            logger.debug(f"Command output: {output}")
+            return output
+        except subprocess.CalledProcessError as exc:
+            logger.error(f"Command failed with error: {exc}")
+            raise exc

--- a/tests/test_endpoints_v4alpha.py
+++ b/tests/test_endpoints_v4alpha.py
@@ -4,7 +4,8 @@ from mock import MagicMock, AsyncMock
 import pytest
 
 
-class TestCASV2Login:
+class TestCreateJobList:
+    """Test suite for the create job list endpoint in v4alpha."""
     endpoint = "/v4alpha/experiments/{expid}/create-job-list"
 
     def test_disabled_runner(self, fixture_fastapi_client: TestClient):

--- a/tests/test_endpoints_v4alpha.py
+++ b/tests/test_endpoints_v4alpha.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from mock import MagicMock, AsyncMock
+import pytest
+
+
+class TestCASV2Login:
+    endpoint = "/v4alpha/experiments/{expid}/create-job-list"
+
+    def test_disabled_runner(self, fixture_fastapi_client: TestClient):
+        RANDOM_EXPID = "foobar1234567890"
+
+        with patch(
+            "autosubmit_api.routers.v4alpha.check_runner_permissions"
+        ) as mock_check_permissions:
+            mock_check_permissions.return_value = False
+            response = fixture_fastapi_client.post(
+                self.endpoint.format(expid=RANDOM_EXPID),
+                json={
+                    "runner": "local",
+                    "module_loader": "no_module",
+                    "modules": None,
+                },
+            )
+
+        assert response.status_code == 403
+
+    def test_fail_create_job_list(self, fixture_fastapi_client: TestClient):
+        RANDOM_EXPID = "foobar1234567890"
+
+        with (
+            patch(
+                "autosubmit_api.routers.v4alpha.check_runner_permissions"
+            ) as mock_check_permissions,
+            patch("autosubmit_api.routers.v4alpha.get_runner") as mock_get_runner,
+        ):
+            mock_check_permissions.return_value = True
+            mock_create_job_list = AsyncMock()
+            mock_create_job_list.side_effect = Exception("Failed to create job list")
+            mock_runner = MagicMock()
+            mock_runner.create_job_list = mock_create_job_list
+            mock_get_runner.return_value = mock_runner
+
+            response = fixture_fastapi_client.post(
+                self.endpoint.format(expid=RANDOM_EXPID),
+                json={
+                    "runner": "local",
+                    "module_loader": "no_module",
+                    "modules": None,
+                },
+            )
+
+            assert response.status_code == 500
+
+    @pytest.mark.parametrize(
+        "check_wrapper",
+        [True, False],
+    )
+    def test_enabled_runner(
+        self, fixture_fastapi_client: TestClient, check_wrapper: bool
+    ):
+        RANDOM_EXPID = "foobar1234567890"
+
+        with (
+            patch(
+                "autosubmit_api.routers.v4alpha.check_runner_permissions"
+            ) as mock_check_permissions,
+            patch("autosubmit_api.routers.v4alpha.get_runner") as mock_get_runner,
+        ):
+            mock_check_permissions.return_value = True
+
+            mock_create_job_list = AsyncMock()
+            mock_runner = MagicMock()
+            mock_runner.create_job_list = mock_create_job_list
+            mock_get_runner.return_value = mock_runner
+
+            response = fixture_fastapi_client.post(
+                self.endpoint.format(expid=RANDOM_EXPID),
+                json={
+                    "runner": "local",
+                    "module_loader": "no_module",
+                    "modules": None,
+                    "check_wrapper": check_wrapper,
+                },
+            )
+
+            assert response.status_code == 200
+
+            mock_create_job_list.assert_awaited_once_with(RANDOM_EXPID, check_wrapper)

--- a/tests/test_endpoints_v4alpha.py
+++ b/tests/test_endpoints_v4alpha.py
@@ -6,6 +6,7 @@ import pytest
 
 class TestCreateJobList:
     """Test suite for the create job list endpoint in v4alpha."""
+
     endpoint = "/v4alpha/experiments/{expid}/create-job-list"
 
     def test_disabled_runner(self, fixture_fastapi_client: TestClient):
@@ -54,12 +55,14 @@ class TestCreateJobList:
             assert response.status_code == 500
 
     @pytest.mark.parametrize(
-        "check_wrapper",
-        [True, False],
+        "params",
+        [
+            {"check_wrapper": True},
+            {"check_wrapper": False, "update_version": True},
+            {"check_wrapper": False, "force": True},
+        ],
     )
-    def test_enabled_runner(
-        self, fixture_fastapi_client: TestClient, check_wrapper: bool
-    ):
+    def test_enabled_runner(self, fixture_fastapi_client: TestClient, params: dict):
         RANDOM_EXPID = "foobar1234567890"
 
         with (
@@ -81,10 +84,15 @@ class TestCreateJobList:
                     "runner": "local",
                     "module_loader": "no_module",
                     "modules": None,
-                    "check_wrapper": check_wrapper,
+                    **params,
                 },
             )
 
             assert response.status_code == 200
 
-            mock_create_job_list.assert_awaited_once_with(RANDOM_EXPID, check_wrapper)
+            mock_create_job_list.assert_awaited_once_with(
+                RANDOM_EXPID,
+                check_wrapper=params.get("check_wrapper"),
+                update_version=params.get("update_version"),
+                force=params.get("force"),
+            )

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -163,3 +163,25 @@ async def test_create_job_list(fixture_mock_basic_config, check_wrapper: bool):
         else:
             assert "--check-wrapper" not in command
 
+
+@pytest.mark.asyncio
+async def test_create_job_list_cmd_fail(fixture_mock_basic_config):
+    module_loader = NoModuleLoader()
+    runner = LocalRunner(module_loader)
+
+    TEST_EXPID = "test_expid"
+
+    # Mock the command generation
+    with patch(
+        "autosubmit_api.runners.local_runner.subprocess.check_output"
+    ) as mock_check_output:
+        mock_check_output.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="autosubmit create"
+        )
+
+        # Call the method and expect an exception
+        with pytest.raises(subprocess.CalledProcessError):
+            await runner.create_job_list(TEST_EXPID, check_wrapper=False)
+
+        # Verify the command was called once
+        mock_check_output.assert_called_once()

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -128,3 +128,38 @@ async def test_stop_experiment_success(fixture_mock_basic_config, force_stop: bo
 
         # Verify the repository status update
         mock_update_process_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "check_wrapper",
+    [
+        pytest.param(True, id="check_wrapper_true"),
+        pytest.param(False, id="check_wrapper_false"),
+    ],
+)
+async def test_create_job_list(fixture_mock_basic_config, check_wrapper: bool):
+    module_loader = NoModuleLoader()
+    runner = LocalRunner(module_loader)
+
+    TEST_EXPID = "test_expid"
+
+    # Mock the command generation
+    with patch(
+        "autosubmit_api.runners.local_runner.subprocess.check_output"
+    ) as mock_check_output:
+        # Call the method
+        await runner.create_job_list(TEST_EXPID, check_wrapper=check_wrapper)
+
+        # Verify the command was called once
+        mock_check_output.assert_called_once()
+
+        # Verifiy that the command contains the experiment ID
+        command = mock_check_output.call_args[0][0]
+        assert "autosubmit create" in command
+        assert TEST_EXPID in command
+        if check_wrapper:
+            assert "--check-wrapper" in command
+        else:
+            assert "--check-wrapper" not in command
+

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -1,6 +1,8 @@
-from unittest.mock import patch, AsyncMock, MagicMock
-import pytest
 import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from autosubmit_api.runners.local_runner import LocalRunner
 from autosubmit_api.runners.module_loaders import NoModuleLoader
 
@@ -154,7 +156,7 @@ async def test_create_job_list(fixture_mock_basic_config, check_wrapper: bool):
         # Verify the command was called once
         mock_check_output.assert_called_once()
 
-        # Verifiy that the command contains the experiment ID
+        # Verify that the command contains the experiment ID
         command = mock_check_output.call_args[0][0]
         assert "autosubmit create" in command
         assert TEST_EXPID in command


### PR DESCRIPTION
Related to: #55 

Opposite to using `autosubmit expid`, `autosubmit create` seems to be safe to use.

Possible options in the new endpoint:

- `check_wrappers`: activates the `-cw` flag of the `autosubmit create` command
- `update_version`: same as `-v` to force update to the used version
- `force`: same as `-f` forcing the re-creation of the job list