### PR TITLE
Add create expid to runners

### DIFF
--- a/autosubmit_api/runners/base.py
+++ b/autosubmit_api/runners/base.py
@@ -64,3 +64,9 @@ class Runner(ABC):
 
         :param expid: The expid of the experiment to create a job list for.
         """
+
+    @abstractmethod
+    async def create_experiment(self):
+        """
+        Create an Autosubmit experiment.
+        """

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -299,6 +299,6 @@ class LocalRunner(Runner):
             expid = match.group(1)
             logger.info(f"Experiment {expid} created successfully.")
             return expid
-        except subprocess.CalledProcessError as exc:
+        except Exception as exc:
             logger.error(f"Command failed with error: {exc}")
             raise exc

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -1,7 +1,9 @@
 import asyncio
 import asyncio.subprocess
+import re
 import signal
 import subprocess
+from typing import Optional
 
 import psutil
 
@@ -247,5 +249,56 @@ class LocalRunner(Runner):
             logger.debug(f"Command output: {output}")
             return output
         except Exception as exc:
+            logger.error(f"Command failed with error: {exc}")
+            raise exc
+
+    async def create_experiment(
+        self,
+        description: str,
+        git_repo: Optional[str] = None,
+        git_branch: Optional[str] = None,
+        minimal: bool = False,
+        config_path: Optional[str] = None,
+        hpc: Optional[str] = None,
+        use_local_minimal: bool = False,
+        operational: bool = False,
+        testcase: bool = False,
+    ) -> str:
+        flags = [f'--description="{description}"']
+        if git_repo:
+            flags.append(f'--git_repo="{git_repo}"')
+        if git_branch:
+            flags.append(f'--git_branch="{git_branch}"')
+        if minimal:
+            flags.append("--minimal_configuration")
+        if config_path:
+            flags.append(f'-conf="{config_path}"')
+        if hpc:
+            flags.append(f'--HPC="{hpc}"')
+        if use_local_minimal:
+            flags.append("--use_local_minimal")
+        if operational:
+            flags.append("--operational")
+        if testcase:
+            flags.append("--testcase")
+
+        autosubmit_command = f"autosubmit expid {' '.join(flags)}"
+        wrapped_command = self.module_loader.generate_command(autosubmit_command)
+
+        try:
+            logger.debug(f"Running command: {wrapped_command}")
+            output = subprocess.check_output(
+                wrapped_command, shell=True, text=True, executable="/bin/bash"
+            ).strip()
+            logger.debug(f"Command output: {output}")
+
+            # Extract the experiment ID from the output
+            match = re.search(r"Experiment (\w+) created", output)
+            if not match:
+                raise RuntimeError("Failed to extract experiment ID from output.")
+            expid = match.group(1)
+            logger.info(f"Experiment {expid} created successfully.")
+            return expid
+        except subprocess.CalledProcessError as exc:
             logger.error(f"Command failed with error: {exc}")
             raise exc

--- a/tests/test_endpoints_v4alpha.py
+++ b/tests/test_endpoints_v4alpha.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch
-from fastapi.testclient import TestClient
-from mock import MagicMock, AsyncMock
+
 import pytest
+from fastapi.testclient import TestClient
+from mock import AsyncMock, MagicMock
 
 
 class TestCreateJobList:
@@ -96,3 +97,84 @@ class TestCreateJobList:
                 update_version=params.get("update_version"),
                 force=params.get("force"),
             )
+
+
+class TestRunnerCreateExperiment:
+    endpoint = "/v4alpha/runner-create-experiment"
+
+    def test_disabled_runner(self, fixture_fastapi_client: TestClient):
+        with patch(
+            "autosubmit_api.routers.v4alpha.check_runner_permissions"
+        ) as mock_check_permissions:
+            mock_check_permissions.return_value = False
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={
+                    "runner": "local",
+                    "module_loader": "no_module",
+                    "modules": None,
+                    "description": "Test experiment",
+                },
+            )
+
+        assert response.status_code == 403
+
+    def test_fail_create_job_list(self, fixture_fastapi_client: TestClient):
+        with (
+            patch(
+                "autosubmit_api.routers.v4alpha.check_runner_permissions"
+            ) as mock_check_permissions,
+            patch("autosubmit_api.routers.v4alpha.get_runner") as mock_get_runner,
+        ):
+            mock_check_permissions.return_value = True
+            mock_create_experiment = AsyncMock()
+            mock_create_experiment.side_effect = Exception(
+                "Failed to create experiment"
+            )
+            mock_runner = MagicMock()
+            mock_runner.create_experiment = mock_create_experiment
+            mock_get_runner.return_value = mock_runner
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={
+                    "runner": "local",
+                    "module_loader": "no_module",
+                    "modules": None,
+                    "description": "Test experiment",
+                },
+            )
+
+            assert response.status_code == 500
+
+    def test_enabled_runner(self, fixture_fastapi_client: TestClient):
+        with (
+            patch(
+                "autosubmit_api.routers.v4alpha.check_runner_permissions"
+            ) as mock_check_permissions,
+            patch("autosubmit_api.routers.v4alpha.get_runner") as mock_get_runner,
+        ):
+            mock_check_permissions.return_value = True
+
+            mock_create_experiment = AsyncMock()
+            mock_create_experiment.return_value = "test_expid"
+            mock_runner = MagicMock()
+            mock_runner.create_experiment = mock_create_experiment
+            mock_get_runner.return_value = mock_runner
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={
+                    "runner": "local",
+                    "module_loader": "no_module",
+                    "modules": None,
+                    "description": "Test experiment",
+                },
+            )
+            resp_obj = response.json()
+
+            assert response.status_code == 200
+
+            mock_create_experiment.assert_awaited_once()
+
+            assert resp_obj["expid"] == "test_expid"

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -194,3 +194,27 @@ async def test_create_job_list_cmd_fail(fixture_mock_basic_config):
 
         # Verify the command was called once
         mock_check_output.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_experiment(fixture_mock_basic_config):
+    module_loader = NoModuleLoader()
+    runner = LocalRunner(module_loader)
+
+    TEST_EXPID = "test_expid"
+
+    # Mock the command generation
+    with patch(
+        "autosubmit_api.runners.local_runner.subprocess.check_output"
+    ) as mock_check_output:
+        mock_check_output.return_value = f"Experiment {TEST_EXPID} created successfully"
+
+        # Call the method
+        expid = await runner.create_experiment(description="Test Experiment")
+
+        assert expid == TEST_EXPID
+
+        command = mock_check_output.call_args[0][0]
+
+        assert "autosubmit expid" in command
+        assert '--description="Test Experiment"' in command


### PR DESCRIPTION
Related to #55 

Implements a way to create new experiments from the API using `autosubmit expid`

Options:

* `--description [DESC]`
* `--git_repo [REPO]`
* `--git_branch [BRANCH]`
* `--minimal_configuration`
* `-conf [PATH]`
* `--HPC [HPC]`
* `--use_local_minimal`
* `--operational`
* `--testcase`

UPDATE: With the secret token auth #212, there is now an additional way to secure this endpoint. That's necessary due to its vulnerability risk.