### PR TITLE
SSH Runner

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,113 @@
+name: SSH API Runner Node Tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  test-ssh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    services:
+      ssh-api-runner-node:
+        image: autosubmit/testing-images:ssh-api-runner-node
+        ports:
+          - 2222:22
+        options: --name ssh-api-runner-node
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate SSH keys
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N ""
+          echo "SSH key generated."
+
+      - name: Append the public key to the container's authorized_keys
+        run: |
+          docker exec ssh-api-runner-node sh -c "echo $(cat ~/.ssh/id_rsa.pub) >> /home/autosubmit_user/.ssh/authorized_keys"
+          docker exec ssh-api-runner-node chmod 600 /home/autosubmit_user/.ssh/authorized_keys
+          echo "Public key added to authorized_keys in the container."
+
+      - name: Wait for SSH service to be ready
+        run: |
+          for i in {1..30}; do
+              if ssh -o StrictHostKeyChecking=no -p 2222 autosubmit_user@localhost true; then
+                  echo "SSH is ready!"
+                  break
+              fi
+              echo "Waiting for SSH service..."
+              sleep 1
+              done
+
+      - name: Run tests
+        run: |
+          ssh -o StrictHostKeyChecking=no -p 2222 autosubmit_user@localhost "echo 'SSH connection successful!'"
+
+      - name: Setup autosubmit
+        run: |
+          ssh -o StrictHostKeyChecking=no -p 2222 autosubmit_user@localhost "bash -ic 'conda run -n autosubmit_env autosubmit configure'"
+          ssh -o StrictHostKeyChecking=no -p 2222 autosubmit_user@localhost "bash -ic 'conda run -n autosubmit_env autosubmit install'"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y graphviz
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[all]
+
+      - name: Run tests
+        run: |
+          pytest -vv -m ssh_runner
+
+      - name: Coverage report
+        run: |
+          coverage xml
+          coverage report
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_ssh_runner
+          path: coverage.xml
+          retention-days: 7
+
+  coverage:
+    needs: test-ssh
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Codecov upload
+        uses: codecov/codecov-action@v5
+        with:
+          name: ${{ github.workflow }}
+          flags: fast-tests
+          fail_ci_if_error: true
+          verbose: true
+          # Token not required for public repos, but avoids upload failure due
+          # to rate-limiting (but not for PRs opened from forks)
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/autosubmit_api/database/tables.py
+++ b/autosubmit_api/database/tables.py
@@ -242,6 +242,7 @@ RunnerProcessesTable = Table(
     Column("modules", Text, nullable=False),
     Column("created", Text, nullable=False),
     Column("modified", Text, nullable=False),
+    Column("runner_extra_params", Text, nullable=True),
 )
 
 JobPklTable = Table(

--- a/autosubmit_api/repositories/runner_processes.py
+++ b/autosubmit_api/repositories/runner_processes.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 from sqlalchemy import Engine, Table, create_engine
@@ -23,6 +23,7 @@ class RunnerProcessesDataModel(BaseModel):
     modules: str
     created: str
     modified: str
+    runner_extra_params: Optional[str] = None
 
 
 class RunnerProcessesRepository(ABC):
@@ -49,6 +50,7 @@ class RunnerProcessesRepository(ABC):
         runner: str,
         module_loader: str,
         modules: str,
+        runner_extra_params: str = None,
     ) -> RunnerProcessesDataModel:
         """
         Inserts a new process status
@@ -70,8 +72,8 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
         self.engine = engine
         self.table = table
 
-        # Create the table if it doesn't exist
         with self.engine.connect() as conn:
+            # Create the table if it doesn't exist
             conn.execute(CreateTable(self.table, if_not_exists=True))
             conn.commit()
 
@@ -94,6 +96,7 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
                 modules=row.modules,
                 created=row.created,
                 modified=row.modified,
+                runner_extra_params=row.runner_extra_params,
             )
             for row in result
         ]
@@ -119,6 +122,7 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
             modules=result.modules,
             created=result.created,
             modified=result.modified,
+            runner_extra_params=result.runner_extra_params,
         )
 
     def insert_process(
@@ -129,6 +133,7 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
         runner: str,
         module_loader: str,
         modules: str,
+        runner_extra_params: str = None,
     ) -> RunnerProcessesDataModel:
         with self.engine.connect() as conn:
             _now = datetime.now(tz=LOCAL_TZ).isoformat(timespec="seconds")
@@ -141,6 +146,7 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
                 modules=modules,
                 created=_now,
                 modified=_now,
+                runner_extra_params=runner_extra_params,
             )
             result = conn.execute(statement)
             conn.commit()
@@ -154,6 +160,7 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
             modules=modules,
             created=_now,
             modified=_now,
+            runner_extra_params=runner_extra_params,
         )
 
     def update_process_status(self, id: int, status: str) -> RunnerProcessesDataModel:
@@ -183,6 +190,7 @@ class RunnerProcessesSQLRepository(RunnerProcessesRepository):
             modules=result.modules,
             created=result.created,
             modified=_now,
+            runner_extra_params=result.runner_extra_params,
         )
 
 

--- a/autosubmit_api/runners/base.py
+++ b/autosubmit_api/runners/base.py
@@ -6,6 +6,7 @@ from autosubmit_api.repositories.runner_processes import RunnerProcessesDataMode
 
 class RunnerType(str, Enum):
     LOCAL = "local"
+    SSH = "ssh"
 
 class RunnerProcessStatus(str, Enum):
     ACTIVE = "ACTIVE"

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -247,7 +247,7 @@ class LocalRunner(Runner):
         """
         flags = []
         if check_wrapper:
-            flags.append("--check-wrapper")
+            flags.append("--check_wrapper")
         if update_version:
             flags.append("--update_version")
         if force:

--- a/autosubmit_api/runners/module_loaders.py
+++ b/autosubmit_api/runners/module_loaders.py
@@ -132,7 +132,7 @@ class VenvModuleLoader(ModuleLoader):
 
     @property
     def base_command(self):
-        return f"source {self.modules[0].strip()}/bin/activate && "
+        return f"{self.modules[0].strip()}/bin/"
 
     def generate_command(self, command: str, *args, **kwargs):
         """

--- a/autosubmit_api/runners/module_loaders.py
+++ b/autosubmit_api/runners/module_loaders.py
@@ -91,7 +91,7 @@ class LmodModuleLoader(ModuleLoader):
 
     @property
     def base_command(self):
-        return f"module load {' '.join(self.modules)} && "
+        return f"module load {' '.join(self.modules)}; "
 
     def generate_command(self, command: str, *args, **kwargs):
         """

--- a/autosubmit_api/runners/ssh_runner.py
+++ b/autosubmit_api/runners/ssh_runner.py
@@ -211,7 +211,10 @@ class SSHRunner(Runner):
             raise RunnerAlreadyRunningError(expid)
 
         autosubmit_command = f"autosubmit run {expid}"
-        prepared_command = "nohup " + self._prepare_command(autosubmit_command)
+        if self.module_loader.module_loader_type == module_loaders.ModuleLoaderType.LMOD:
+            prepared_command = self._prepare_command("nohup " + autosubmit_command)
+        else:
+            prepared_command = "nohup " + self._prepare_command(autosubmit_command)
 
         # Execute the command asynchronously and get a channel to track PID
         self._ensure_connection()

--- a/autosubmit_api/runners/ssh_runner.py
+++ b/autosubmit_api/runners/ssh_runner.py
@@ -1,0 +1,341 @@
+import asyncio
+import asyncio.subprocess
+import json
+import re
+import subprocess
+from typing import Optional
+
+import psutil
+
+from autosubmit_api.logger import logger
+from autosubmit_api.repositories.runner_processes import (
+    create_runner_processes_repository,
+)
+from autosubmit_api.runners import module_loaders
+from autosubmit_api.runners.base import (
+    Runner,
+    RunnerAlreadyRunningError,
+    RunnerProcessStatus,
+    RunnerType,
+)
+
+# Garbage collection prevention: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+background_task = set()
+
+STOP_WAIT_TIMEOUT = 30  # seconds
+
+class SSHRunner(Runner):
+    runner_type = RunnerType.SSH
+
+    def __init__(
+        self,
+        module_loader: module_loaders.ModuleLoader,
+        ssh_host: str,
+        ssh_user: str = None,
+        ssh_port: int = 22,
+    ):
+        if not ssh_host:
+            raise ValueError("SSH host must be provided for SSHRunner.")
+
+        self.module_loader = module_loader
+        self.ssh_host = ssh_host
+        self.ssh_user = ssh_user
+        self.ssh_port = ssh_port
+        self.runners_repo = create_runner_processes_repository()
+
+    def _ssh_prefix(self):
+        user_host = (
+            f"{self.ssh_user}@{self.ssh_host}" if self.ssh_user else self.ssh_host
+        )
+        return f"ssh -o StrictHostKeyChecking=no -p {self.ssh_port} {user_host}"
+
+    def _ssh_command(self, command: str) -> str:
+        """
+        Prepare the SSH command to run on the remote host.
+        """
+        if isinstance(self.module_loader, module_loaders.CondaModuleLoader):
+            # Use interactive shell for Conda module loading
+            return f"{self._ssh_prefix()} 'bash -ic \"{command}\"'"
+        return f"{self._ssh_prefix()} '{command}'"
+
+    async def version(self) -> str:
+        """
+        Get the version of the Autosubmit module using the SSH runner in a subprocess asynchronously.
+        """
+        autosubmit_command = "autosubmit -v"
+        wrapped_command = self.module_loader.generate_command(autosubmit_command)
+        ssh_command = self._ssh_command(wrapped_command)
+
+        try:
+            logger.debug(f"Running SSH command: {ssh_command}")
+            output = subprocess.check_output(
+                ssh_command, shell=True, text=True, executable="/bin/bash"
+            ).strip()
+        except subprocess.CalledProcessError as exc:
+            logger.error(f"SSH command failed with error: {exc}")
+            raise exc
+
+        logger.debug(f"SSH command output: {output}")
+        return output
+
+    def _is_pid_running(self, pid: int) -> bool:
+        """
+        Check if a process with the given PID is running.
+
+        :param pid: The PID of the process to check.
+        :return: True if the process is running, False otherwise.
+        """
+        try:
+            process = psutil.Process(pid)
+            return process.is_running()
+        except Exception as exc:
+            logger.error(f"Error checking process {pid}: {exc}")
+            return False
+
+    def get_runner_status(self, expid: str) -> str:
+        """
+        Get the status of the runner for a given expid.
+        It will update the status in the DB if the process is not running anymore.
+
+        :param expid: The experiment ID to get the status of.
+        :return: The status of the experiment.
+        """
+        # Get active processes from the DB
+        active_procs = self.runners_repo.get_active_processes_by_expid(expid)
+        if not active_procs:
+            return "NO_RUNNER"
+
+        # Check if the process is still running
+        pid = active_procs[0].pid
+        is_pid_running = self._is_pid_running(pid)
+
+        if not is_pid_running:
+            # Update the status of the subprocess in the DB
+            updated_proc = self.runners_repo.update_process_status(
+                id=active_procs[0].id, status=RunnerProcessStatus.TERMINATED.value
+            )
+            return updated_proc.status
+        else:
+            return active_procs[0].status
+
+    async def run(self, expid: str):
+        runner_status = self.get_runner_status(expid)
+        if runner_status == RunnerProcessStatus.ACTIVE.value:
+            logger.error(f"Experiment {expid} is already running.")
+            raise RunnerAlreadyRunningError(expid)
+
+        autosubmit_command = f"autosubmit run {expid}"
+        wrapped_command = self.module_loader.generate_command(autosubmit_command)
+        ssh_command = self._ssh_command(wrapped_command)
+
+        logger.debug(f"Running SSH command: {ssh_command}")
+
+        # Get the remote PID
+        process: asyncio.subprocess.Process = await asyncio.create_subprocess_shell(
+            ssh_command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            executable="/bin/bash",
+        )
+
+        # Store the pid in the DB
+        runner_extra_params = {
+            "ssh_host": self.ssh_host,
+            "ssh_user": self.ssh_user if self.ssh_user else None,
+        }
+        runner_proc = self.runners_repo.insert_process(
+            expid=expid,
+            pid=process.pid,
+            status=RunnerProcessStatus.ACTIVE.value,
+            runner=self.runner_type.value,
+            module_loader=self.module_loader.module_loader_type.value,
+            modules="\n".join(self.module_loader.modules),
+            runner_extra_params=json.dumps(runner_extra_params),
+        )
+
+        # Run the wait_run on the background
+        task = asyncio.create_task(self.wait_run(runner_proc.id, process))
+        # Add the task to the background task set to prevent garbage collection
+        background_task.add(task)
+        task.add_done_callback(background_task.discard)
+
+        # Return the runner data
+        return runner_proc
+
+    async def wait_run(
+        self, runner_process_id: int, process: asyncio.subprocess.Process
+    ):
+        """
+        Wait for the Autosubmit experiment to finish and get the output.
+        This method will check the status of the process and update the status in the DB.
+        :param process: The subprocess to wait for.
+        """
+        try:
+            # Wait for the command to finish and get the output
+            stdout, stderr = await process.communicate()
+
+            # Update the status of the subprocess in the DB
+            self.runners_repo.update_process_status(
+                id=runner_process_id,
+                status=RunnerProcessStatus.COMPLETED.value
+                if process.returncode == 0
+                else RunnerProcessStatus.TERMINATED.value,
+            )
+
+            # Check if the command was successful
+            if process.returncode != 0:
+                logger.error(
+                    "Command failed with error. Check the logs for more details."
+                )
+                raise RuntimeError("Command failed with error")
+            logger.debug(
+                f"Runner {runner_process_id} with pid {process.pid} completed successfully."
+            )
+            return stdout, stderr
+        except Exception as exc:
+            logger.error(
+                f"Error while waiting runner {runner_process_id} for process {process.pid}: {exc}"
+            )
+            raise exc
+        finally:
+            await process.wait()
+
+    async def stop(self, expid: str, force: bool = False):
+        """
+        Stop the remote Autosubmit experiment by killing the process.
+        """
+        # Get the process from the DB
+        active_procs = self.runners_repo.get_active_processes_by_expid(expid)
+        if not active_procs:
+            logger.error(f"Experiment {expid} is not running.")
+            raise RuntimeError(f"Experiment {expid} is not running.")
+
+        # Generate the command to stop the experiment
+        flags = "--force" if force else ""
+        autosubmit_command = f"autosubmit stop {flags} {expid}"
+
+        wrapped_command = f"echo y | {self.module_loader.generate_command(autosubmit_command)}"
+        ssh_command = self._ssh_command(wrapped_command)
+
+        # Run the command to stop the experiment
+        logger.debug(f"Stopping experiment {expid} with command: {ssh_command}")
+        try:
+            result = subprocess.run(
+                ssh_command,
+                shell=True,
+                text=True,
+                executable="/bin/bash",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            logger.debug(f"Stop stdout: {result.stdout}")
+            logger.debug(f"Stop stderr: {result.stderr}")
+
+            # Command will return non-zero code because it will think process is zombie
+            # However it only matters that the process is no longer running.
+            pid = active_procs[0].pid
+            process = psutil.Process(pid)
+            process.wait(timeout=STOP_WAIT_TIMEOUT)
+        except Exception as exc:
+            logger.error(f"Failed to stop experiment {expid}: {exc}")
+            raise exc
+
+        logger.debug(f"Experiment {expid} stopped successfully.")
+
+        # Update the status of the subprocess in the DB
+        # NOTE: The final status can be either "STOPPED" or "FAILED"
+        # because of a race condition with the wait_run method.
+        self.runners_repo.update_process_status(
+            id=active_procs[0].id,
+            status=RunnerProcessStatus.TERMINATED.value,
+        )
+
+    async def create_job_list(
+        self,
+        expid: str,
+        check_wrapper: bool = False,
+        update_version: bool = False,
+        force: bool = False,
+    ) -> str:
+        """
+        Create a job list for the given expid using `autosubmit create` command.
+        This method will use a module loader to prepare the environment and run the command.
+
+        :param expid: The experiment ID to create the job list for.
+        :param check_wrapper: If True, the command will check the wrapper script. Default is False.
+        :return: The output of the command.
+        """
+        flags = []
+        if check_wrapper:
+            flags.append("--check-wrapper")
+        if update_version:
+            flags.append("--update_version")
+        if force:
+            flags.append("--force")
+
+        autosubmit_command = f"autosubmit create -np {' '.join(flags)} {expid}"
+        wrapped_command = self.module_loader.generate_command(autosubmit_command)
+        ssh_command = self._ssh_command(wrapped_command)
+
+        try:
+            logger.debug(f"Running SSH command: {ssh_command}")
+            output = subprocess.check_output(
+                ssh_command, shell=True, text=True, executable="/bin/bash"
+            ).strip()
+            logger.debug(f"SSH command output: {output}")
+            return output
+        except subprocess.CalledProcessError as exc:
+            logger.error(f"Command failed with error: {exc}")
+            raise RuntimeError(f"Failed to create job list: {exc}")
+
+    async def create_experiment(
+        self,
+        description: str,
+        git_repo: Optional[str] = None,
+        git_branch: Optional[str] = None,
+        minimal: bool = False,
+        config_path: Optional[str] = None,
+        hpc: Optional[str] = None,
+        use_local_minimal: bool = False,
+        operational: bool = False,
+        testcase: bool = False,
+    ) -> str:
+        flags = [f'--description="{description}"']
+        if git_repo:
+            flags.append(f'--git_repo="{git_repo}"')
+        if git_branch:
+            flags.append(f'--git_branch="{git_branch}"')
+        if minimal:
+            flags.append("--minimal_configuration")
+        if config_path:
+            flags.append(f'-conf="{config_path}"')
+        if hpc:
+            flags.append(f'--HPC="{hpc}"')
+        if use_local_minimal:
+            flags.append("--use_local_minimal")
+        if operational:
+            flags.append("--operational")
+        if testcase:
+            flags.append("--testcase")
+
+        autosubmit_command = f"autosubmit expid {' '.join(flags)}"
+        wrapped_command = self.module_loader.generate_command(autosubmit_command)
+        ssh_command = self._ssh_command(wrapped_command)
+
+        try:
+            logger.debug(f"Running SSH command: {ssh_command}")
+            output = subprocess.check_output(
+                ssh_command, shell=True, text=True, executable="/bin/bash"
+            ).strip()
+            logger.debug(f"SSH command output: {output}")
+
+            # Extract the experiment ID from the output
+            match = re.search(r"Experiment (\w+) created", output)
+            if not match:
+                raise RuntimeError("Failed to extract experiment ID from output.")
+            expid = match.group(1)
+            logger.info(f"Experiment {expid} created successfully.")
+            return expid
+        except Exception as exc:
+            logger.error(f"Command failed with error: {exc}")
+            raise exc

--- a/autosubmit_api/runners/ssh_runner.py
+++ b/autosubmit_api/runners/ssh_runner.py
@@ -413,7 +413,7 @@ class SSHRunner(Runner):
         """
         flags = []
         if check_wrapper:
-            flags.append("--check-wrapper")
+            flags.append("--check_wrapper")
         if update_version:
             flags.append("--update_version")
         if force:

--- a/docker/ssh-api-runner-node/Dockerfile
+++ b/docker/ssh-api-runner-node/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:22.04
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    openssh-server \
+    wget \
+    python3-venv \
+    sudo \
+    && apt-get clean
+
+# Create a non-root user
+RUN useradd -m -s /bin/bash autosubmit_user && \
+    echo 'autosubmit_user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Make /bin/bash the default shell for autosubmit_user
+RUN chsh -s /bin/bash autosubmit_user
+
+# Copy script files to the container
+COPY scripts/ /usr/local/bin/
+
+# Make scripts executable and set ownership
+RUN chmod +x /usr/local/bin/*.sh && \
+    chown -R autosubmit_user:autosubmit_user /usr/local/bin/*.sh
+
+# Change to autosubmit_user for the rest of the Dockerfile
+USER autosubmit_user
+
+# Create authorized_keys directory with an empty authorized_keys file for the autosubmit_user user
+RUN mkdir -p /home/autosubmit_user/.ssh && \
+    chmod 700 /home/autosubmit_user/.ssh && \
+    touch /home/autosubmit_user/.ssh/authorized_keys && \
+    chmod 600 /home/autosubmit_user/.ssh/authorized_keys
+
+# Run installation scripts
+RUN /usr/local/bin/setup-conda.sh && \
+    /usr/local/bin/setup-venv.sh
+
+# Expose SSH port
+EXPOSE 22
+
+# Start SSH service
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/ssh-api-runner-node/scripts/entrypoint.sh
+++ b/docker/ssh-api-runner-node/scripts/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start the SSH service (using sudo since we're running as non-root user)
+sudo service ssh start
+
+# Keep the container running
+tail -f /dev/null

--- a/docker/ssh-api-runner-node/scripts/setup-conda.sh
+++ b/docker/ssh-api-runner-node/scripts/setup-conda.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install Miniconda in user home directory
+cd /home/autosubmit_user
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+bash miniconda.sh -b -u -p /home/autosubmit_user/miniconda3
+rm miniconda.sh
+export PATH="/home/autosubmit_user/miniconda3/bin:$PATH"
+conda init --all
+conda tos accept
+
+# Create conda environment
+conda create -y -n autosubmit_env python=3.10
+
+# Install autosubmit package
+conda run -n autosubmit_env pip install autosubmit==4.1.14

--- a/docker/ssh-api-runner-node/scripts/setup-venv.sh
+++ b/docker/ssh-api-runner-node/scripts/setup-venv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+VENV_PATH=/home/autosubmit_user/autosubmit_venv
+
+# Create a Python virtual environment named 'autosubmit_venv' in user home
+python3 -m venv $VENV_PATH
+
+# Install the autosubmit package in the virtual environment
+$VENV_PATH/bin/pip install --upgrade pip
+$VENV_PATH/bin/pip install autosubmit==4.1.14

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 addopts =
     --cov=autosubmit_api --cov-config=.coveragerc --cov-report=html
     --cov-report=xml:coverage.xml
+    -m "not ssh_runner"
 testpaths =
     tests/
 doctest_optionflags =

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     "uvicorn-worker~=0.3.0",
     "psycopg2",
     "testcontainers",
+    "paramiko",
 ]
 
 # Test dependencies

--- a/tests/test_local_runner.py
+++ b/tests/test_local_runner.py
@@ -140,7 +140,7 @@ async def test_stop_experiment_success(fixture_mock_basic_config, force_stop: bo
     [
         (
             {"check_wrapper": True, "update_version": True},
-            ["--check-wrapper", "--update_version"],
+            ["--check_wrapper", "--update_version"],
         ),
         (
             {"check_wrapper": False, "force": True},

--- a/tests/test_module_loaders.py
+++ b/tests/test_module_loaders.py
@@ -49,7 +49,7 @@ def test_get_module_loader(module_loader_name, modules, expected):
     "module_loader_name, modules, expected_cmd",
     [
         (ModuleLoaderType.CONDA.value, "foo", "conda run -n"),
-        (ModuleLoaderType.VENV, "/foo", "source /foo/bin/activate"),
+        (ModuleLoaderType.VENV, "/foo", "/foo/bin/"),
         (ModuleLoaderType.LMOD.value, "foo", "module load foo"),
         (ModuleLoaderType.LMOD.value, ["foo", "bar"], "module load foo bar"),
         (ModuleLoaderType.NO_MODULE.value, None, ""),

--- a/tests/test_ssh_runner.py
+++ b/tests/test_ssh_runner.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+import pytest
+
+from autosubmit_api.runners.base import RunnerProcessStatus, RunnerType
+from autosubmit_api.runners.module_loaders import CondaModuleLoader, VenvModuleLoader
+from autosubmit_api.runners.runner_factory import get_runner
+from autosubmit_api.runners.ssh_runner import SSHRunner
+
+
+@pytest.mark.asyncio
+@pytest.mark.ssh_runner
+@pytest.mark.parametrize(
+    "module_loader",
+    [
+        CondaModuleLoader(env_name="autosubmit_env"),
+        VenvModuleLoader(venv_path="/home/autosubmit_user/autosubmit_venv"),
+    ],
+)
+async def test_ssh_runner_version(fixture_mock_basic_config, module_loader):
+    runner = get_runner(
+        runner_type=RunnerType.SSH,
+        module_loader=module_loader,
+        ssh_host="localhost",
+        ssh_user="autosubmit_user",
+        ssh_port=2222,
+    )
+
+    version = await runner.version()
+
+    assert version == "4.1.14"
+
+
+@pytest.mark.asyncio
+@pytest.mark.ssh_runner
+@pytest.mark.parametrize(
+    "module_loader",
+    [
+        CondaModuleLoader(env_name="autosubmit_env"),
+        VenvModuleLoader(venv_path="/home/autosubmit_user/autosubmit_venv"),
+    ],
+)
+async def test_ssh_runner_full_run(fixture_mock_basic_config, module_loader):
+    runner: SSHRunner = get_runner(
+        runner_type=RunnerType.SSH,
+        module_loader=module_loader,
+        ssh_host="localhost",
+        ssh_user="autosubmit_user",
+        ssh_port=2222,
+    )
+
+    # Create a new experiment
+    expid = await runner.create_experiment(
+        description="Test experiment",
+    )
+
+    # Create a job list for the experiment
+    await runner.create_job_list(expid=expid)
+
+    # Run the experiment
+    with patch("autosubmit_api.runners.ssh_runner.SSHRunner.wait_run") as mock_wait_run:
+        mock_wait_run.return_value = True # Don't wait for the run to finish
+
+        runner_proc = await runner.run(expid=expid)
+        assert runner_proc is not None
+        assert runner_proc.expid == expid
+        assert runner_proc.status == RunnerProcessStatus.ACTIVE.value
+
+    # Check runner status
+    status = runner.get_runner_status(expid=expid)
+    assert status == RunnerProcessStatus.ACTIVE.value
+
+    # Stop the experiment
+    await runner.stop(expid=expid)
+
+    # Check if the process is stopped
+    status = runner.get_runner_status(expid=expid)
+    assert status != RunnerProcessStatus.ACTIVE.value


### PR DESCRIPTION
PR to implement the SSH Runner. This runner should be able to execute commands via SSH using details provided by the user in the endpoint request.

Inside the usual endpoint request body, users should provide:

```json
{
  "runner_extra_params": {
    "ssh_host": "...",
    "ssh_user": "...",
    "ssh_port": 22
  }
}
```

- [x] Support runner methods
  - [x] version
  - [x] get_runner_status
  - [x] run
  - [x] wait_run
  - [x] stop
  - [x] create_job_list
  - [x] create_experiment 
- [x] Testing
  - [x] Build a docker image (https://hub.docker.com/layers/autosubmit/testing-images/ssh-api-runner-node/images/sha256-1abb52cc1cb27d4ba9d0d28fe1ebf5b3ea57a5b3d8c0d732077b006fd2504336) 
  - [x] Update pytest to mark ssh tests
  - [x] Create a new GitHub action with the SSH container
  - [x] Cover runner methods with tests