### PR TITLE
Update v4 jobs endpoint to handle pagination

### DIFF
--- a/autosubmit_api/models/responses.py
+++ b/autosubmit_api/models/responses.py
@@ -35,6 +35,7 @@ class ExperimentsSearchResponse(BaseModel):
 
 class ExperimentJobsResponse(BaseModel):
     jobs: List[PklJobModel]
+    pagination: PaginationInfo
 
 
 class ExperimentFSConfigResponse(BaseModel):


### PR DESCRIPTION
As part of the priorities of https://github.com/BSC-ES/autosubmit-gui/issues/330

This PR aims to retrieve the job list in a shorter time since in big experiments it takes a long time to return the job list. This will allow us to show a shorter list and navigate through the list pages. Then, the Quick View page will be able to show content as soon as possible, but there will be more cost when changing pages.

Unfortunately, this change will be only visible by experiments that will include this Autosubmit update https://github.com/BSC-ES/autosubmit/pull/2391. Previous versions will remain the same or be slower to navigate.