### PR TITLE
Add create expid endpoint

### DIFF
--- a/autosubmit_api/runners/base.py
+++ b/autosubmit_api/runners/base.py
@@ -76,7 +76,19 @@ class Runner(ABC):
         """
 
     @abstractmethod
-    async def create_experiment(self):
+    async def create_experiment(
+        self,
+        description: str,
+        git_repo: Optional[str] = None,
+        git_branch: Optional[str] = None,
+        minimal: bool = False,
+        config_path: Optional[str] = None,
+        hpc: Optional[str] = None,
+        use_local_minimal: bool = False,
+        operational: bool = False,
+        testcase: bool = False,
+        copy: Optional[str] = None,
+    ):
         """
         Create an Autosubmit experiment.
         """

--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -281,6 +281,7 @@ class LocalRunner(Runner):
         use_local_minimal: bool = False,
         operational: bool = False,
         testcase: bool = False,
+        copy: Optional[str] = None,
     ) -> str:
         flags = [f'--description="{description}"']
         if git_repo:
@@ -299,6 +300,8 @@ class LocalRunner(Runner):
             flags.append("--operational")
         if testcase:
             flags.append("--testcase")
+        if copy:
+            flags.append(f'--copy="{copy}"')
 
         autosubmit_command = f"autosubmit expid {' '.join(flags)}"
         wrapped_command = self.module_loader.generate_command(autosubmit_command)

--- a/autosubmit_api/runners/ssh_runner.py
+++ b/autosubmit_api/runners/ssh_runner.py
@@ -449,6 +449,7 @@ class SSHRunner(Runner):
         use_local_minimal: bool = False,
         operational: bool = False,
         testcase: bool = False,
+        copy: Optional[str] = None,
     ) -> str:
         flags = [f'--description="{description}"']
         if git_repo:
@@ -467,6 +468,8 @@ class SSHRunner(Runner):
             flags.append("--operational")
         if testcase:
             flags.append("--testcase")
+        if copy:
+            flags.append(f'--copy="{copy}"')
 
         autosubmit_command = f"autosubmit expid {' '.join(flags)}"
         prepared_command = self._prepare_command(autosubmit_command)


### PR DESCRIPTION
This PR will add the production-ready endpoints to create an experiment by triggering `autosubmit expid` using the runner profiles that are already introduced in the API.

 - [x] /v4/runners/command/create-experiment