### PR TITLE
RtD fix setuptools dep

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==80.10.2
 livereload
 pydata-sphinx-theme==0.16.*
 sphinx==7.*


### PR DESCRIPTION
Quick workaround to make RtD builds succeed.

The issue was introduced in the latest version of setuptools (82.0.0), which doesn't include the `pkg_resources` module.

Failed RtD build: https://app.readthedocs.org/projects/autosubmit-api/builds/31334716/