### PR TITLE
Add toggles to disable the interactivity endpoints

### DIFF
--- a/autosubmit_api/routers/v4/runners.py
+++ b/autosubmit_api/routers/v4/runners.py
@@ -69,8 +69,10 @@ def get_runner_configuration_endpoints(
         "RUNNER_RUN": {"ENABLED": True},
     }
 
-    # Merge default endpoints with the ones from the config, giving priority to the config values
-    merged_endpoints = {**default_endpoints, **endpoints}
+    merged_endpoints = {}
+    for key in set(default_endpoints.keys()):
+        merged_endpoints[key] = {**default_endpoints[key], **endpoints.get(key, {})}
+
     return merged_endpoints
 
 

--- a/autosubmit_api/routers/v4/runners.py
+++ b/autosubmit_api/routers/v4/runners.py
@@ -51,6 +51,29 @@ def get_runner_configuration_profiles(
     return profiles
 
 
+@router.get("/configuration/endpoints", name="Get runner configuration endpoints")
+def get_runner_configuration_endpoints(
+    user_id: Optional[str] = Depends(auth_token_dependency()),
+) -> Dict[str, Any]:
+    """
+    Get the runner configuration endpoints from the configuration file.
+    """
+    config = read_config_file()
+    endpoints = config.get("RUNNER_CONFIGURATION", {}).get("ENDPOINTS", {})
+    if not isinstance(endpoints, dict):
+        endpoints = {}
+
+    default_endpoints = {
+        "SET_JOB_STATUS": {"ENABLED": True},
+        "CREATE_EXPERIMENT": {"ENABLED": True},
+        "RUNNER_RUN": {"ENABLED": True},
+    }
+
+    # Merge default endpoints with the ones from the config, giving priority to the config values
+    merged_endpoints = {**default_endpoints, **endpoints}
+    return merged_endpoints
+
+
 class RunnerEndpointBody(BaseModel):
     profile_name: str
     profile_params: Optional[Dict[str, Any]] = None
@@ -74,6 +97,13 @@ class SetJobStatusBody(RunnerEndpointBody):
     command_params: SetJobStatusCmdParams
 
 
+def _endpoint_enabled(endpoint_name: str) -> bool:
+    config = read_config_file()
+    endpoints = config.get("RUNNER_CONFIGURATION", {}).get("ENDPOINTS", {})
+    endpoint_config = endpoints.get(endpoint_name, {})
+    return endpoint_config.get("ENABLED", True)
+
+
 @router.post("/command/set-job-status", name="Set job status for an experiment")
 async def set_job_status(
     body: SetJobStatusBody,
@@ -82,6 +112,12 @@ async def set_job_status(
     """
     Set the job status for an experiment using the specified runner profile.
     """
+    if not _endpoint_enabled("SET_JOB_STATUS"):
+        raise HTTPException(
+            status_code=403,
+            detail="The set-job-status endpoint is currently disabled.",
+        )
+
     expid = body.expid
     command_params = body.command_params
 
@@ -128,6 +164,12 @@ async def run_experiment(
     """
     Run an experiment using the specified runner profile.
     """
+    if not _endpoint_enabled("RUNNER_RUN"):
+        raise HTTPException(
+            status_code=403,
+            detail="The run-experiment endpoint is currently disabled.",
+        )
+
     expid = body.expid
 
     logger.info(f"Starting experiment {expid} using profile {body.profile_name}")
@@ -174,6 +216,12 @@ async def get_runner_run_status(
     """
     Get the status of the runner run for a given experiment ID.
     """
+    if not _endpoint_enabled("RUNNER_RUN"):
+        raise HTTPException(
+            status_code=403,
+            detail="The get-runner-run-status endpoint is currently disabled.",
+        )
+
     expid = body.expid
 
     logger.info(f"Getting runner run status for experiment {expid}")
@@ -215,6 +263,12 @@ async def stop_experiment(
     """
     Stop an experiment using the specified runner profile.
     """
+    if not _endpoint_enabled("RUNNER_RUN"):
+        raise HTTPException(
+            status_code=403,
+            detail="The stop-experiment endpoint is currently disabled.",
+        )
+
     expid = body.expid
 
     logger.info(f"Stopping experiment {expid}")
@@ -256,6 +310,12 @@ async def create_experiment(
     """
     Create an experiment using the specified runner profile.
     """
+    if not _endpoint_enabled("CREATE_EXPERIMENT"):
+        raise HTTPException(
+            status_code=403,
+            detail="The create-experiment endpoint is currently disabled.",
+        )
+
     command_params = body.command_params
 
     logger.info(f"Creating experiment using profile {body.profile_name}")

--- a/tests/test_endpoints_v4.py
+++ b/tests/test_endpoints_v4.py
@@ -515,6 +515,37 @@ class TestRunnerSetJobStatus:
 
         assert response.status_code != 200
 
+    def test_disabled_endpoint(self, fixture_fastapi_client: TestClient):
+        with patch(
+            "autosubmit_api.routers.v4.runners.read_config_file"
+        ) as mock_read_config:
+            mock_read_config.return_value = {
+                "RUNNER_CONFIGURATION": {
+                    "PROFILES": {
+                        "MY_PROFILE": {
+                            "RUNNER_TYPE": "LOCAL",
+                            "MODULE_LOADER_TYPE": "NO_MODULE",
+                        }
+                    },
+                    "ENDPOINTS": {"SET_JOB_STATUS": {"ENABLED": False}},
+                },
+            }
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={
+                    "expid": "test_expid",
+                    "profile_name": "MY_PROFILE",
+                    "command_params": {
+                        "final_status": "COMPLETED",
+                        "job_names_list": ["JOB1", "JOB2"],
+                    },
+                },
+            )
+
+            assert response.status_code == 403
+            assert "disabled" in response.json()["error_message"]
+
     def test_valid_ssh_request(self, fixture_fastapi_client: TestClient):
         # Mock read_config_file to include SSH_AUTOSUBMIT_DEV profile
         # and get_runner to return a mock runner
@@ -750,3 +781,19 @@ class TestRunnerCreateExperiment:
         )
 
         assert response.status_code != 200
+
+
+class TestRunnerConfigurations:
+    def test_endpoints_configuration(self, fixture_fastapi_client: TestClient):
+        endpoint = "/v4/runners/configuration/endpoints"
+
+        response = fixture_fastapi_client.get(
+            endpoint,
+        )
+
+        resp_obj: dict = response.json()
+
+        for endpoint_name in ["SET_JOB_STATUS", "RUNNER_RUN", "CREATE_EXPERIMENT"]:
+            assert endpoint_name in resp_obj
+            assert "ENABLED" in resp_obj[endpoint_name]
+            assert isinstance(resp_obj[endpoint_name]["ENABLED"], bool)

--- a/tests/test_endpoints_v4.py
+++ b/tests/test_endpoints_v4.py
@@ -598,6 +598,27 @@ class TestRunnerSetJobStatus:
 class TestRunnerRunExperiment:
     endpoint = "/v4/runners/command/run-experiment"
 
+    def test_disabled_endpoint(self, fixture_fastapi_client: TestClient):
+        with patch(
+            "autosubmit_api.routers.v4.runners.read_config_file"
+        ) as mock_read_config:
+            mock_read_config.return_value = {
+                "RUNNER_CONFIGURATION": {
+                    "ENDPOINTS": {"RUNNER_RUN": {"ENABLED": False}},
+                },
+            }
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={
+                    "expid": "test_expid",
+                    "profile_name": "ANY_PROFILE",
+                },
+            )
+
+            assert response.status_code == 403
+            assert "disabled" in response.json()["error_message"]
+
     def test_valid_ssh_request(self, fixture_fastapi_client: TestClient):
         with (
             patch(
@@ -642,6 +663,24 @@ class TestRunnerRunExperiment:
 
 class TestRunnerGetRunnerRunStatus:
     endpoint = "/v4/runners/command/get-runner-run-status"
+
+    def test_disabled_endpoint(self, fixture_fastapi_client: TestClient):
+        with patch(
+            "autosubmit_api.routers.v4.runners.read_config_file"
+        ) as mock_read_config:
+            mock_read_config.return_value = {
+                "RUNNER_CONFIGURATION": {
+                    "ENDPOINTS": {"RUNNER_RUN": {"ENABLED": False}},
+                },
+            }
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={"expid": "test_expid"},
+            )
+
+            assert response.status_code == 403
+            assert "disabled" in response.json()["error_message"]
 
     def test_valid_request(self, fixture_fastapi_client: TestClient):
         with patch(
@@ -700,6 +739,24 @@ class TestRunnerGetRunnerRunStatus:
 class TestRunnerStopExperiment:
     endpoint = "/v4/runners/command/stop-experiment"
 
+    def test_disabled_endpoint(self, fixture_fastapi_client: TestClient):
+        with patch(
+            "autosubmit_api.routers.v4.runners.read_config_file"
+        ) as mock_read_config:
+            mock_read_config.return_value = {
+                "RUNNER_CONFIGURATION": {
+                    "ENDPOINTS": {"RUNNER_RUN": {"ENABLED": False}},
+                },
+            }
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={"expid": "test_expid"},
+            )
+
+            assert response.status_code == 403
+            assert "disabled" in response.json()["error_message"]
+
     def test_valid_ssh_request(self, fixture_fastapi_client: TestClient):
         with patch(
             "autosubmit_api.routers.v4.runners.get_runner_from_expid"
@@ -733,6 +790,29 @@ class TestRunnerStopExperiment:
 
 class TestRunnerCreateExperiment:
     endpoint = "/v4/runners/command/create-experiment"
+
+    def test_disabled_endpoint(self, fixture_fastapi_client: TestClient):
+        with patch(
+            "autosubmit_api.routers.v4.runners.read_config_file"
+        ) as mock_read_config:
+            mock_read_config.return_value = {
+                "RUNNER_CONFIGURATION": {
+                    "ENDPOINTS": {"CREATE_EXPERIMENT": {"ENABLED": False}},
+                },
+            }
+
+            response = fixture_fastapi_client.post(
+                self.endpoint,
+                json={
+                    "profile_name": "ANY_PROFILE",
+                    "command_params": {
+                        "description": "Test experiment",
+                    },
+                },
+            )
+
+            assert response.status_code == 403
+            assert "disabled" in response.json()["error_message"]
 
     def test_valid_local_request(self, fixture_fastapi_client: TestClient):
         with (
@@ -784,16 +864,91 @@ class TestRunnerCreateExperiment:
 
 
 class TestRunnerConfigurations:
-    def test_endpoints_configuration(self, fixture_fastapi_client: TestClient):
+    @pytest.mark.parametrize(
+        "file_content, expected",
+        [
+            (
+                {},
+                {
+                    "SET_JOB_STATUS": {"ENABLED": True},
+                    "RUNNER_RUN": {"ENABLED": True},
+                    "CREATE_EXPERIMENT": {"ENABLED": True},
+                },
+            ),
+            (
+                {
+                    "RUNNER_CONFIGURATION": {
+                        "ENDPOINTS": {
+                            "SET_JOB_STATUS": {"ENABLED": False},
+                            "RUNNER_RUN": {"ENABLED": False},
+                            "CREATE_EXPERIMENT": {"ENABLED": False},
+                        }
+                    }
+                },
+                {
+                    "SET_JOB_STATUS": {"ENABLED": False},
+                    "RUNNER_RUN": {"ENABLED": False},
+                    "CREATE_EXPERIMENT": {"ENABLED": False},
+                },
+            ),
+            (
+                {
+                    "RUNNER_CONFIGURATION": {
+                        "ENDPOINTS": {
+                            "SET_JOB_STATUS": {
+                                "ENABLED": False,
+                                "EXTRA_KEY": "foo",
+                            },
+                            "CREATE_EXPERIMENT": {"ENABLED": True},
+                        }
+                    }
+                },
+                {
+                    "SET_JOB_STATUS": {"ENABLED": False, "EXTRA_KEY": "foo"},
+                    "RUNNER_RUN": {"ENABLED": True},
+                    "CREATE_EXPERIMENT": {"ENABLED": True},
+                },
+            ),
+            (
+                {
+                    "RUNNER_CONFIGURATION": {
+                        "ENDPOINTS": {
+                            "SET_JOB_STATUS": {
+                                "EXTRA_KEY": "foo",
+                            },
+                        }
+                    }
+                },
+                {
+                    "SET_JOB_STATUS": {"ENABLED": True, "EXTRA_KEY": "foo"},
+                    "RUNNER_RUN": {"ENABLED": True},
+                    "CREATE_EXPERIMENT": {"ENABLED": True},
+                },
+            ),
+        ],
+    )
+    def test_endpoints_configuration(
+        self, fixture_fastapi_client: TestClient, file_content: dict, expected: dict
+    ):
         endpoint = "/v4/runners/configuration/endpoints"
 
-        response = fixture_fastapi_client.get(
-            endpoint,
-        )
+        with patch(
+            "autosubmit_api.routers.v4.runners.read_config_file"
+        ) as mock_read_config:
+            mock_read_config.return_value = file_content
+
+            response = fixture_fastapi_client.get(
+                endpoint,
+            )
 
         resp_obj: dict = response.json()
 
-        for endpoint_name in ["SET_JOB_STATUS", "RUNNER_RUN", "CREATE_EXPERIMENT"]:
-            assert endpoint_name in resp_obj
-            assert "ENABLED" in resp_obj[endpoint_name]
-            assert isinstance(resp_obj[endpoint_name]["ENABLED"], bool)
+        assert resp_obj == expected
+
+        # for endpoint_name in ["SET_JOB_STATUS", "RUNNER_RUN", "CREATE_EXPERIMENT"]:
+        #     assert endpoint_name in resp_obj
+        #     assert "ENABLED" in resp_obj[endpoint_name]
+        #     assert (
+        #         isinstance(resp_obj[endpoint_name]["ENABLED"], bool)
+        #         and resp_obj[endpoint_name]["ENABLED"] is True
+        #     )


### PR DESCRIPTION
With this PR, the API will expose an endpoint to enable or disable some interactivity endpoints by modifying the configuration yaml file like this:

```yaml
RUNNER_CONFIGURATION:
  ENDPOINTS:
    SET_JOB_STATUS:
      ENABLED: True
    CREATE_EXPERIMENT:
      ENABLED: False
    RUNNER_RUN:
      ENABLED: True
```

By default, all endpoints are enabled.