### PR TITLE
Add a single job details endpoint

### DIFF
--- a/autosubmit_api/autosubmit_legacy/job/job_utils.py
+++ b/autosubmit_api/autosubmit_legacy/job/job_utils.py
@@ -18,6 +18,7 @@
 # along with Autosubmit.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+from typing import Dict, List
 
 
 class SubJob(object):
@@ -42,14 +43,20 @@ class SubJobManager(object):
     Class to manage list of SubJobs
     """
 
-    def __init__(self, subjoblist, job_to_package=None, package_to_jobs=None, current_structure=None):
+    def __init__(
+        self,
+        subjoblist: List[SubJob],
+        job_to_package: Dict[str, str] = None,
+        package_to_jobs: Dict[str, List[str]] = None,
+        current_structure: Dict[str, List[str]] =None,
+    ):
         self.subjobList = subjoblist
         # print("Number of jobs in SubManager : {}".format(len(self.subjobList)))
         self.job_to_package = job_to_package
         self.package_to_jobs = package_to_jobs
         self.current_structure = current_structure
-        self.subjobindex = dict()
-        self.subjobfixes = dict()
+        self.subjobindex: Dict[str, SubJob] = dict()
+        self.subjobfixes: Dict[str, SubJob] = dict()
         self.process_index()
         self.process_times()
 
@@ -72,7 +79,7 @@ class SubJobManager(object):
                     # SubJobs in Package
                     local_structure = dict()
                     # SubJob Name -> SubJob Object
-                    local_index = dict()
+                    local_index: Dict[str, SubJob] = dict()
                     subjobs_in_package = [x for x in self.subjobList if x.package ==
                                                 package]
                     local_jobs_in_package = [job for job in subjobs_in_package]

--- a/autosubmit_api/common/utils.py
+++ b/autosubmit_api/common/utils.py
@@ -7,7 +7,7 @@ import math
 from collections import namedtuple
 from bscearth.utils.date import date2str
 from dateutil.relativedelta import relativedelta
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 LOCAL_TZ = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
 
@@ -193,7 +193,7 @@ def get_experiments_from_folder(root_folder: str) -> List[str]:
   folders = stdOut.split()      
   return [expid for expid in folders if len(expid) == 4]
 
-def timestamp_to_datetime_format(timestamp: int) -> str:
+def timestamp_to_datetime_format(timestamp: Optional[int]) -> str:
   """
   Formats a timestamp to a iso format datetime string with timezone information.
   """

--- a/autosubmit_api/components/jobs/job_detail.py
+++ b/autosubmit_api/components/jobs/job_detail.py
@@ -1,0 +1,206 @@
+from datetime import datetime
+from typing import List, Optional
+
+from autosubmit_api.builders.configuration_facade_builder import (
+    AutosubmitConfigurationFacadeBuilder,
+    ConfigurationFacadeDirector,
+)
+from autosubmit_api.repositories.experiment_run import (
+    ExperimentRunModel,
+    create_experiment_run_repository,
+)
+from autosubmit_api.repositories.job_data import (
+    ExperimentJobDataModel,
+    create_experiment_job_data_repository,
+)
+from autosubmit_api.repositories.job_packages import (
+    JobPackageModel,
+    create_job_packages_repository,
+)
+from autosubmit_api.repositories.jobs import JobData, create_jobs_repository
+
+
+class JobNotFoundError(Exception):
+    """Exception raised when a job is not found."""
+
+
+class JobDetailRetriever:
+    """
+    Class to get the details of a single job.
+    """
+
+    def __init__(self, expid: str, job_name: str):
+        self.expid = expid
+        self.job_name = job_name
+
+        self._job_data: Optional[JobData] = None
+        self._run_data: Optional[ExperimentRunModel] = None
+        self._historical_data: Optional[ExperimentJobDataModel] = None
+        self._config_facade = None
+        self._wrapper_data: List[JobPackageModel] = []
+
+        self.warnings = []
+
+    def load_data(self):
+        self._load_base_job_data()
+        self._load_experiment_run_data()
+        self._load_historical_job_last_data()
+        self._load_config_files_data()
+        self._load_wrapper_data()
+
+    def _load_base_job_data(self):
+        try:
+            job_list_repo = create_jobs_repository(self.expid)
+            self._job_data = job_list_repo.get_by_name(self.job_name)
+            if not self._job_data:
+                raise JobNotFoundError()
+        except Exception:
+            raise JobNotFoundError()
+
+    def _load_experiment_run_data(self):
+        try:
+            run_repo = create_experiment_run_repository(self.expid)
+            self._run_data = run_repo.get_last_run()
+        except Exception:
+            self.warnings.append("Failed to load experiment run data")
+
+    def _load_historical_job_last_data(self):
+        try:
+            job_data_repo = create_experiment_job_data_repository(self.expid)
+            self._historical_data = job_data_repo.get_last_job_data_by_name(
+                self.job_name
+            )
+        except Exception:
+            self.warnings.append("Failed to load historical job data")
+
+    def _load_config_files_data(self):
+        try:
+            autosubmit_config_facade = ConfigurationFacadeDirector(
+                AutosubmitConfigurationFacadeBuilder(self.expid)
+            ).build_autosubmit_configuration_facade()
+            self._config_facade = autosubmit_config_facade
+        except Exception:
+            self.warnings.append("Failed to load config files data")
+
+    def _load_wrapper_data(self):
+        try:
+            job_package_repo = create_job_packages_repository(self.expid)
+            job_packages = job_package_repo.get_by_job_name(self.job_name)
+            self._wrapper_data = job_packages if job_packages else []
+        except Exception:
+            self.warnings.append("Failed to load job package data")
+
+    @property
+    def name(self) -> str:
+        return self.job_name
+
+    @property
+    def status_code(self) -> Optional[int]:
+        return self._job_data.status
+
+    @property
+    def section(self) -> Optional[str]:
+        return self._job_data.section
+
+    @property
+    def date(self) -> Optional[datetime]:
+        return self._job_data.date
+
+    @property
+    def member(self) -> Optional[str]:
+        return self._job_data.member
+
+    @property
+    def chunk(self) -> Optional[int]:
+        return self._job_data.chunk
+
+    @property
+    def chunk_size(self) -> Optional[int]:
+        if self._config_facade and self._config_facade.chunk_size is not None:
+            return self._config_facade.chunk_size
+        elif self._run_data and self._run_data.chunk_size is not None:
+            return self._run_data.chunk_size
+        return None
+
+    @property
+    def chunk_unit(self) -> Optional[str]:
+        if self._config_facade and self._config_facade.chunk_unit is not None:
+            return self._config_facade.chunk_unit
+        elif self._run_data and self._run_data.chunk_unit is not None:
+            return self._run_data.chunk_unit
+        return None
+
+    @property
+    def platform(self) -> Optional[str]:
+        section_platform = (
+            self._config_facade.get_section_platform(self.section)
+            if self._config_facade
+            else None
+        )
+        if section_platform is not None:
+            return section_platform
+        elif self._historical_data and self._historical_data.platform is not None:
+            return self._historical_data.platform
+        return None
+
+    @property
+    def remote_id(self) -> Optional[str]:
+        return self._historical_data.job_id if self._historical_data else None
+
+    @property
+    def qos(self) -> Optional[str]:
+        section_qos = (
+            self._config_facade.get_section_qos(self.section)
+            if self._config_facade
+            else None
+        )
+        if section_qos is not None:
+            return section_qos
+        elif self._historical_data and self._historical_data.qos is not None:
+            return self._historical_data.qos
+        return None
+
+    @property
+    def processors(self) -> Optional[int]:
+        section_processors = (
+            self._config_facade.get_section_processors(self.section)
+            if self._config_facade
+            else None
+        )
+        if section_processors is not None:
+            return section_processors
+        elif self._historical_data and self._historical_data.nnodes is not None:
+            return self._historical_data.nnodes
+        return None
+
+    @property
+    def wallclock(self) -> Optional[str]:
+        section_wallclock = (
+            self._config_facade.get_section_wallclock(self.section)
+            if self._config_facade
+            else None
+        )
+        if section_wallclock is not None:
+            return section_wallclock
+        elif self._historical_data and self._historical_data.wallclock is not None:
+            return self._historical_data.wallclock
+        return None
+
+    @property
+    def workflow_commit(self) -> Optional[str]:
+        config_workflow_commit = (
+            self._config_facade.get_workflow_commit() if self._config_facade else None
+        )
+        if config_workflow_commit is not None:
+            return config_workflow_commit
+        elif (
+            self._historical_data and self._historical_data.workflow_commit is not None
+        ):
+            return self._historical_data.workflow_commit
+        return None
+
+    @property
+    def last_wrapper(self) -> Optional[str]:
+        if self._wrapper_data:
+            return self._wrapper_data[-1].package_name
+        return None

--- a/autosubmit_api/components/jobs/job_detail.py
+++ b/autosubmit_api/components/jobs/job_detail.py
@@ -5,6 +5,7 @@ from autosubmit_api.builders.configuration_facade_builder import (
     AutosubmitConfigurationFacadeBuilder,
     ConfigurationFacadeDirector,
 )
+from autosubmit_api.components.jobs.utils import get_fixed_experiment_times
 from autosubmit_api.repositories.experiment_run import (
     ExperimentRunModel,
     create_experiment_run_repository,
@@ -33,12 +34,19 @@ class JobDetailRetriever:
         self.expid = expid
         self.job_name = job_name
 
+        # Initialize data stores to None
         self._job_data: Optional[JobData] = None
         self._run_data: Optional[ExperimentRunModel] = None
         self._historical_data: Optional[ExperimentJobDataModel] = None
         self._config_facade = None
         self._wrapper_data: List[JobPackageModel] = []
 
+        # Initialize times to None
+        self._submit = None
+        self._start = None
+        self._finish = None
+
+        # Initialize warnings list
         self.warnings = []
 
     def load_data(self):
@@ -47,6 +55,7 @@ class JobDetailRetriever:
         self._load_historical_job_last_data()
         self._load_config_files_data()
         self._load_wrapper_data()
+        self._load_times()
 
     def _load_base_job_data(self):
         job_list_repo = create_jobs_repository(self.expid)
@@ -99,6 +108,17 @@ class JobDetailRetriever:
             self.warnings.append(
                 {"message": "Failed to load job package data", "exception": str(exc)}
             )
+
+    def _load_times(self):
+        if self._job_data:
+            try:
+                self._submit, self._start, self._finish = get_fixed_experiment_times(
+                    self.expid, self._job_data, self._historical_data
+                )
+            except Exception as exc:
+                self.warnings.append(
+                    {"message": "Failed to load job times", "exception": str(exc)}
+                )
 
     @property
     def name(self) -> str:
@@ -154,7 +174,7 @@ class JobDetailRetriever:
         return None
 
     @property
-    def remote_id(self) -> Optional[str]:
+    def remote_id(self) -> Optional[int]:
         return self._historical_data.job_id if self._historical_data else None
 
     @property
@@ -214,3 +234,15 @@ class JobDetailRetriever:
         if self._wrapper_data:
             return self._wrapper_data[-1].package_name
         return None
+
+    @property
+    def submit(self) -> Optional[int]:
+        return self._submit
+    
+    @property
+    def start(self) -> Optional[int]:
+        return self._start
+    
+    @property
+    def finish(self) -> Optional[int]:
+        return self._finish

--- a/autosubmit_api/components/jobs/job_detail.py
+++ b/autosubmit_api/components/jobs/job_detail.py
@@ -49,20 +49,19 @@ class JobDetailRetriever:
         self._load_wrapper_data()
 
     def _load_base_job_data(self):
-        try:
-            job_list_repo = create_jobs_repository(self.expid)
-            self._job_data = job_list_repo.get_by_name(self.job_name)
-            if not self._job_data:
-                raise JobNotFoundError()
-        except Exception:
+        job_list_repo = create_jobs_repository(self.expid)
+        self._job_data = job_list_repo.get_by_name(self.job_name)
+        if not self._job_data:
             raise JobNotFoundError()
 
     def _load_experiment_run_data(self):
         try:
             run_repo = create_experiment_run_repository(self.expid)
             self._run_data = run_repo.get_last_run()
-        except Exception:
-            self.warnings.append("Failed to load experiment run data")
+        except Exception as exc:
+            self.warnings.append(
+                {"message": "Failed to load experiment run data", "exception": str(exc)}
+            )
 
     def _load_historical_job_last_data(self):
         try:
@@ -70,8 +69,10 @@ class JobDetailRetriever:
             self._historical_data = job_data_repo.get_last_job_data_by_name(
                 self.job_name
             )
-        except Exception:
-            self.warnings.append("Failed to load historical job data")
+        except Exception as exc:
+            self.warnings.append(
+                {"message": "Failed to load historical job data", "exception": str(exc)}
+            )
 
     def _load_config_files_data(self):
         try:
@@ -79,16 +80,25 @@ class JobDetailRetriever:
                 AutosubmitConfigurationFacadeBuilder(self.expid)
             ).build_autosubmit_configuration_facade()
             self._config_facade = autosubmit_config_facade
-        except Exception:
-            self.warnings.append("Failed to load config files data")
+        except Exception as exc:
+            self.warnings.append(
+                {"message": "Failed to load config files data", "exception": str(exc)}
+            )
 
     def _load_wrapper_data(self):
         try:
             job_package_repo = create_job_packages_repository(self.expid)
             job_packages = job_package_repo.get_by_job_name(self.job_name)
-            self._wrapper_data = job_packages if job_packages else []
-        except Exception:
-            self.warnings.append("Failed to load job package data")
+            if not job_packages:
+                job_package_repo = create_job_packages_repository(
+                    self.expid, wrapper=True
+                )
+                job_packages = job_package_repo.get_by_job_name(self.job_name)
+            self._wrapper_data = job_packages
+        except Exception as exc:
+            self.warnings.append(
+                {"message": "Failed to load job package data", "exception": str(exc)}
+            )
 
     @property
     def name(self) -> str:
@@ -169,8 +179,8 @@ class JobDetailRetriever:
         )
         if section_processors is not None:
             return section_processors
-        elif self._historical_data and self._historical_data.nnodes is not None:
-            return self._historical_data.nnodes
+        elif self._historical_data and self._historical_data.ncpus is not None:
+            return self._historical_data.ncpus
         return None
 
     @property

--- a/autosubmit_api/components/jobs/utils.py
+++ b/autosubmit_api/components/jobs/utils.py
@@ -2,131 +2,196 @@
 
 import datetime
 import os
-from autosubmit_api.common.utils import Status
-from typing import List, Dict, Tuple
-from bscearth.utils.date import parse_date
 import subprocess
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
-wrapped_title_format = " <span class='badge' style='background-color:#94b8b8'>Wrapped {0} </span>"
+from bscearth.utils.date import parse_date
+
+from autosubmit_api.common.utils import Status
+from autosubmit_api.persistance.experiment import ExperimentPaths
+
+if TYPE_CHECKING:
+    from autosubmit_api.repositories.job_data import ExperimentJobDataModel
+    from autosubmit_api.repositories.jobs import JobData
+
+
+wrapped_title_format = (
+    " <span class='badge' style='background-color:#94b8b8'>Wrapped {0} </span>"
+)
 source_tag = " <span class='badge' style='background-color:#80d4ff'>SOURCE</span>"
 target_tag = " <span class='badge' style='background-color:#99ff66'>TARGET</span>"
-sync_tag = " <span class='badge' style='background-color:#0066ff; color:white'>SYNC</span>"
+sync_tag = (
+    " <span class='badge' style='background-color:#0066ff; color:white'>SYNC</span>"
+)
 checkmark_tag = " <span class='badge' style='background-color:#4dffa6'>&#10004;</span>"
 
-completed_tag_with_anchors = " <span class='badge' style='background-color:%B'> %C / %T COMPLETED</span>"
-running_tag_with_anchors = " <span class='badge' style='background-color:green; color:#fff'>%R RUNNING</span>"
-queuing_tag_with_anchors = " <span class='badge' style='background-color:pink'>%Q QUEUING</span>"
-failed_tag_with_anchors = " <span class='badge' style='background-color:red'>%F FAILED</span>"
-held_tag_with_anchors = " <span class='badge' style='background-color:#fa8072; color:#fff'>%H HELD</span>"
+completed_tag_with_anchors = (
+    " <span class='badge' style='background-color:%B'> %C / %T COMPLETED</span>"
+)
+running_tag_with_anchors = (
+    " <span class='badge' style='background-color:green; color:#fff'>%R RUNNING</span>"
+)
+queuing_tag_with_anchors = (
+    " <span class='badge' style='background-color:pink'>%Q QUEUING</span>"
+)
+failed_tag_with_anchors = (
+    " <span class='badge' style='background-color:red'>%F FAILED</span>"
+)
+held_tag_with_anchors = (
+    " <span class='badge' style='background-color:#fa8072; color:#fff'>%H HELD</span>"
+)
 
 # Status.HELD, Status.PREPARED
-SUBMIT_STATUS = {Status.COMPLETED, Status.FAILED, Status.QUEUING, Status.RUNNING, Status.SUBMITTED}
+SUBMIT_STATUS = {
+    Status.COMPLETED,
+    Status.FAILED,
+    Status.QUEUING,
+    Status.RUNNING,
+    Status.SUBMITTED,
+}
 START_STATUS = {Status.COMPLETED, Status.FAILED, Status.RUNNING}
 FINISH_STATUS = {Status.COMPLETED, Status.FAILED}
 
+
 def is_a_completed_retrial(fields: List[str]) -> bool:
-  """ Identifies one line of _TOTAL_STATS file """
-  if len(fields) == 4:
-    if fields[3] == 'COMPLETED':
-      return True
-  return False
+    """Identifies one line of _TOTAL_STATS file"""
+    if len(fields) == 4:
+        if fields[3] == "COMPLETED":
+            return True
+    return False
+
 
 def get_corrected_submit_time_by_status(status_code: int, submit_time: str) -> str:
-  if status_code in SUBMIT_STATUS:
-    return submit_time
-  return None
+    if status_code in SUBMIT_STATUS:
+        return submit_time
+    return None
+
 
 def get_corrected_start_time_by_status(status_code: int, start_time: str) -> str:
-  if status_code in START_STATUS:
-    return start_time
-  return None
+    if status_code in START_STATUS:
+        return start_time
+    return None
+
 
 def get_corrected_finish_time_by_status(status_code: int, finish_time: str) -> str:
-  if status_code in FINISH_STATUS:
-    return finish_time
-  return None
+    if status_code in FINISH_STATUS:
+        return finish_time
+    return None
+
 
 def get_status_text_color(status_code: int) -> str:
-  if status_code in [Status.RUNNING, Status.FAILED, Status.HELD]:
-    return "#fff"
-  return "#000"
+    if status_code in [Status.RUNNING, Status.FAILED, Status.HELD]:
+        return "#fff"
+    return "#000"
 
 
 def get_folder_checkmark(completed_count: int, jobs_in_folder_count: int) -> str:
-  if completed_count == jobs_in_folder_count:
-      return checkmark_tag
-  return ""
+    if completed_count == jobs_in_folder_count:
+        return checkmark_tag
+    return ""
+
 
 def get_folder_completed_tag(completed_count: int, jobs_in_folder_count: int) -> str:
-  tag = ""
-  if completed_count == jobs_in_folder_count:
-      tag = "<span class='badge' style='background-color:yellow'>"
-  else:
-      tag = "<span class='badge' style='background-color:#ffffb3'>"
-  return  "{0} {1} / {2} COMPLETED</span>".format(tag, completed_count, jobs_in_folder_count)
+    tag = ""
+    if completed_count == jobs_in_folder_count:
+        tag = "<span class='badge' style='background-color:yellow'>"
+    else:
+        tag = "<span class='badge' style='background-color:#ffffb3'>"
+    return "{0} {1} / {2} COMPLETED</span>".format(
+        tag, completed_count, jobs_in_folder_count
+    )
+
 
 def get_folder_running_tag(running_count: int) -> str:
-  if running_count > 0:
-    return " <span class='badge' style='background-color:green; color:#fff'>{0} RUNNING</span>".format(running_count)
-  return ""
+    if running_count > 0:
+        return " <span class='badge' style='background-color:green; color:#fff'>{0} RUNNING</span>".format(
+            running_count
+        )
+    return ""
+
 
 def get_folder_queuing_tag(queuing_count: int) -> str:
-  if queuing_count > 0:
-    return " <span class='badge' style='background-color:pink'>{0} QUEUING</span>".format(queuing_count)
-  return ""
+    if queuing_count > 0:
+        return " <span class='badge' style='background-color:pink'>{0} QUEUING</span>".format(
+            queuing_count
+        )
+    return ""
+
 
 def get_folder_failed_tag(failed_count: int) -> str:
-  if failed_count > 0:
-    return " <span class='badge' style='background-color:red'>{0} FAILED</span>".format(failed_count)
-  return ""
+    if failed_count > 0:
+        return " <span class='badge' style='background-color:red'>{0} FAILED</span>".format(
+            failed_count
+        )
+    return ""
+
 
 def get_folder_held_tag(held_count: int) -> str:
-  if held_count > 0:
-    return " <span class='badge' style='background-color:#fa8072; color:#fff'>{0} HELD</span>".format(held_count)
-  return ""
+    if held_count > 0:
+        return " <span class='badge' style='background-color:#fa8072; color:#fff'>{0} HELD</span>".format(
+            held_count
+        )
+    return ""
+
 
 def get_date_folder_tag(title: str, startdate_count: int) -> str:
-  # set the proper color
-  if title == "COMPLETED":
-      color = "yellow"
-  if title == "WAITING":
-      color = "#aaa"
-  if title == "SUSPENDED":
-      color = "orange"
-  tag = "<span class='badge' style='background-color:{0}'>".format(color)
-  return  "{0} {1} / {2} {3} </span>".format(tag, startdate_count, startdate_count, title)
+    # set the proper color
+    if title == "COMPLETED":
+        color = "yellow"
+    if title == "WAITING":
+        color = "#aaa"
+    if title == "SUSPENDED":
+        color = "orange"
+    tag = "<span class='badge' style='background-color:{0}'>".format(color)
+    return "{0} {1} / {2} {3} </span>".format(
+        tag, startdate_count, startdate_count, title
+    )
 
-def get_folder_date_member_title(expid: str, formatted_date: str, member: str, date_member_jobs_count: int, counters: Dict[int, int]) -> str:
-  return "{0}_{1}_{2} {3}{4}{5}{6}{7}{8}".format(
-      expid,
-      formatted_date,
-      member,
-      get_folder_completed_tag(counters[Status.COMPLETED], date_member_jobs_count),
-      get_folder_failed_tag(counters[Status.FAILED]),
-      get_folder_running_tag(counters[Status.RUNNING]),
-      get_folder_queuing_tag(counters[Status.QUEUING]),
-      get_folder_held_tag(counters[Status.HELD]),
-      get_folder_checkmark(counters[Status.COMPLETED], date_member_jobs_count)
-  )
 
-def get_folder_package_title(package_name: str, jobs_count: int, counters: Dict[int, int]) -> str:
-  return "Wrapper: {0} {1}{2}{3}{4}{5}{6}".format(
-      package_name,
-      get_folder_completed_tag(counters[Status.COMPLETED], jobs_count),
-      get_folder_failed_tag(counters[Status.FAILED]),
-      get_folder_running_tag(counters[Status.RUNNING]),
-      get_folder_queuing_tag(counters[Status.QUEUING]),
-      get_folder_held_tag(counters[Status.HELD]),
-      get_folder_checkmark(counters[Status.COMPLETED], jobs_count)
-  )
+def get_folder_date_member_title(
+    expid: str,
+    formatted_date: str,
+    member: str,
+    date_member_jobs_count: int,
+    counters: Dict[int, int],
+) -> str:
+    return "{0}_{1}_{2} {3}{4}{5}{6}{7}{8}".format(
+        expid,
+        formatted_date,
+        member,
+        get_folder_completed_tag(counters[Status.COMPLETED], date_member_jobs_count),
+        get_folder_failed_tag(counters[Status.FAILED]),
+        get_folder_running_tag(counters[Status.RUNNING]),
+        get_folder_queuing_tag(counters[Status.QUEUING]),
+        get_folder_held_tag(counters[Status.HELD]),
+        get_folder_checkmark(counters[Status.COMPLETED], date_member_jobs_count),
+    )
+
+
+def get_folder_package_title(
+    package_name: str, jobs_count: int, counters: Dict[int, int]
+) -> str:
+    return "Wrapper: {0} {1}{2}{3}{4}{5}{6}".format(
+        package_name,
+        get_folder_completed_tag(counters[Status.COMPLETED], jobs_count),
+        get_folder_failed_tag(counters[Status.FAILED]),
+        get_folder_running_tag(counters[Status.RUNNING]),
+        get_folder_queuing_tag(counters[Status.QUEUING]),
+        get_folder_held_tag(counters[Status.HELD]),
+        get_folder_checkmark(counters[Status.COMPLETED], jobs_count),
+    )
+
 
 def convert_int_default(value, default_value=None):
-  try:
-    return int(value)
-  except Exception:
-    return default_value
-  
-def get_job_total_stats(status_code: int, name: str, tmp_path: str) -> Tuple[datetime.datetime, datetime.datetime, datetime.datetime, str]:
+    try:
+        return int(value)
+    except Exception:
+        return default_value
+
+
+def get_job_total_stats(
+    status_code: int, name: str, tmp_path: str
+) -> Tuple[datetime.datetime, datetime.datetime, datetime.datetime, str]:
     """
     Receives job data and returns the data from its TOTAL_STATS file in an ordered way.
     Function migrated from the legacy JobList class method _job_running_check()
@@ -143,47 +208,43 @@ def get_job_total_stats(status_code: int, name: str, tmp_path: str) -> Tuple[dat
     start_time = now
     finish_time = now
     current_status = status_from_job
-    path = os.path.join(tmp_path, name + '_TOTAL_STATS')
+    path = os.path.join(tmp_path, name + "_TOTAL_STATS")
     if os.path.exists(path):
-        last_line = subprocess.check_output(['tail', '-1', path], text=True)
+        last_line = subprocess.check_output(["tail", "-1", path], text=True)
 
         values = last_line.split()
         try:
             if status_code in [Status.RUNNING]:
-                submit_time = parse_date(
-                    values[0]) if len(values) > 0 else now
-                start_time = parse_date(values[1]) if len(
-                    values) > 1 else submit_time
+                submit_time = parse_date(values[0]) if len(values) > 0 else now
+                start_time = parse_date(values[1]) if len(values) > 1 else submit_time
                 finish_time = now
             elif status_code in [Status.QUEUING, Status.SUBMITTED, Status.HELD]:
-                submit_time = parse_date(
-                    values[0]) if len(values) > 0 else now
-                start_time = parse_date(
-                    values[1]) if len(values) > 1 and values[0] != values[1] else now
+                submit_time = parse_date(values[0]) if len(values) > 0 else now
+                start_time = (
+                    parse_date(values[1])
+                    if len(values) > 1 and values[0] != values[1]
+                    else now
+                )
             elif status_code in [Status.COMPLETED]:
-                submit_time = parse_date(
-                    values[0]) if len(values) > 0 else now
-                start_time = parse_date(
-                    values[1]) if len(values) > 1 else submit_time
+                submit_time = parse_date(values[0]) if len(values) > 0 else now
+                start_time = parse_date(values[1]) if len(values) > 1 else submit_time
                 if len(values) > 3:
                     finish_time = parse_date(values[len(values) - 2])
                 else:
                     finish_time = submit_time
             else:
-                submit_time = parse_date(
-                    values[0]) if len(values) > 0 else now
-                start_time = parse_date(values[1]) if len(
-                    values) > 1 else submit_time
-                finish_time = parse_date(values[2]) if len(
-                    values) > 2 else start_time
+                submit_time = parse_date(values[0]) if len(values) > 0 else now
+                start_time = parse_date(values[1]) if len(values) > 1 else submit_time
+                finish_time = parse_date(values[2]) if len(values) > 2 else start_time
         except Exception:
             start_time = now
             finish_time = now
             # NA if reading fails
             current_status = "NA"
 
-    current_status = values[3] if (len(values) > 3 and len(
-        values[3]) != 14) else status_from_job
+    current_status = (
+        values[3] if (len(values) > 3 and len(values[3]) != 14) else status_from_job
+    )
     # TOTAL_STATS last line has more than 3 items, status is different from pkl, and status is not "NA"
     if len(values) > 3 and current_status != status_from_job and current_status != "NA":
         current_status = "SUSPICIOUS"
@@ -192,7 +253,7 @@ def get_job_total_stats(status_code: int, name: str, tmp_path: str) -> Tuple[dat
 
 def job_times_to_text(minutes_queue: int, minutes_running: int, status: str):
     """
-    Return text correpsonding to queue and running time. 
+    Return text correpsonding to queue and running time.
     Function migrated from the legacy job.utils
     :param minutes_queue: seconds queuing (actually using seconds)
     :type minutes_queue: int
@@ -203,22 +264,73 @@ def job_times_to_text(minutes_queue: int, minutes_running: int, status: str):
     :return: string
     """
     if status in ["COMPLETED", "FAILED", "RUNNING"]:
-        running_text = "( " + str(datetime.timedelta(seconds=minutes_queue)) + \
-            " ) + " + \
-            str(datetime.timedelta(seconds=minutes_running))
+        running_text = (
+            "( "
+            + str(datetime.timedelta(seconds=minutes_queue))
+            + " ) + "
+            + str(datetime.timedelta(seconds=minutes_running))
+        )
     elif status in ["SUBMITTED", "QUEUING", "HELD", "HOLD"]:
-        running_text = "( " + \
-            str(datetime.timedelta(seconds=minutes_queue)) + " )"
+        running_text = "( " + str(datetime.timedelta(seconds=minutes_queue)) + " )"
     elif status in ["NA"]:
         running_text = " <small><i><b>NA</b></i></small>"
     else:
         running_text = ""
 
     if status == "SUSPICIOUS":
-        running_text = running_text + \
-            " <small><i><b>SUSPICIOUS</b></i></small>"
+        running_text = running_text + " <small><i><b>SUSPICIOUS</b></i></small>"
     return running_text
 
 
 def generate_job_html_title(job_name: str, status_color: str, status_text: str) -> str:
-    return job_name + " <span class='badge' style='background-color: " + status_color + "'>#" + status_text + "</span>"
+    return (
+        job_name
+        + " <span class='badge' style='background-color: "
+        + status_color
+        + "'>#"
+        + status_text
+        + "</span>"
+    )
+
+
+def get_fixed_experiment_times(
+    expid: str, current_job: "JobData", job_last_data: "ExperimentJobDataModel"
+) -> Tuple[int, int, int]:
+    submit = 0
+    start = 0
+    finish = 0
+
+    # If status is SUSPENDED, set submit/start/finish to None
+    if current_job.status != Status.SUSPENDED:
+        submit = job_last_data.submit
+        start = job_last_data.start
+        finish = job_last_data.finish
+
+    # If the status from the historical DB is different from the jobs repo, try other method to get the times
+
+    if job_last_data.status != Status.VALUE_TO_KEY[current_job.status]:
+        # Try to get the times from the TOTAL_STATS file
+        if current_job.status in [
+            Status.RUNNING,
+            Status.SUBMITTED,
+            Status.QUEUING,
+            Status.FAILED,
+        ]:
+            submit, start, finish, _ = get_job_total_stats(
+                status_code=current_job.status,
+                name=current_job.name,
+                tmp_path=ExperimentPaths(expid).tmp_dir,
+            )
+            submit = int(submit.timestamp())
+            start = (
+                int(start.timestamp())
+                if current_job.status in [Status.RUNNING, Status.FAILED]
+                else 0
+            )
+            finish = (
+                int(finish.timestamp()) if current_job.status in [Status.FAILED] else 0
+            )
+        else:
+            submit = start = finish = 0
+
+    return submit, start, finish

--- a/autosubmit_api/components/jobs/utils.py
+++ b/autosubmit_api/components/jobs/utils.py
@@ -253,7 +253,7 @@ def get_job_total_stats(
 
 def job_times_to_text(minutes_queue: int, minutes_running: int, status: str):
     """
-    Return text correpsonding to queue and running time.
+    Return text corresponding to queue and running time.
     Function migrated from the legacy job.utils
     :param minutes_queue: seconds queuing (actually using seconds)
     :type minutes_queue: int

--- a/autosubmit_api/components/jobs/utils.py
+++ b/autosubmit_api/components/jobs/utils.py
@@ -3,7 +3,7 @@
 import datetime
 import os
 import subprocess
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from bscearth.utils.date import parse_date
 
@@ -294,21 +294,25 @@ def generate_job_html_title(job_name: str, status_color: str, status_text: str) 
 
 
 def get_fixed_experiment_times(
-    expid: str, current_job: "JobData", job_last_data: "ExperimentJobDataModel"
+    expid: str,
+    current_job: "JobData",
+    job_last_data: Optional["ExperimentJobDataModel"],
 ) -> Tuple[int, int, int]:
-    submit = 0
-    start = 0
-    finish = 0
-
-    # If status is SUSPENDED, set submit/start/finish to None
-    if current_job.status != Status.SUSPENDED:
+    # If status is SUSPENDED, set submit/start/finish to 0
+    if current_job.status == Status.SUSPENDED or job_last_data is None:
+        submit = 0
+        start = 0
+        finish = 0
+    else:
         submit = job_last_data.submit
         start = job_last_data.start
         finish = job_last_data.finish
 
     # If the status from the historical DB is different from the jobs repo, try other method to get the times
-
-    if job_last_data.status != Status.VALUE_TO_KEY[current_job.status]:
+    if not job_last_data or (
+        job_last_data
+        and job_last_data.status != Status.VALUE_TO_KEY.get(current_job.status)
+    ):
         # Try to get the times from the TOTAL_STATS file
         if current_job.status in [
             Status.RUNNING,

--- a/autosubmit_api/repositories/experiment_structure.py
+++ b/autosubmit_api/repositories/experiment_structure.py
@@ -26,6 +26,24 @@ class ExperimentStructureRepository(ABC):
         :return experiments: The list of job edges
         """
 
+    @abstractmethod
+    def get_parents(self, job_name: str) -> List[str]:
+        """
+        Get the parent jobs of a given job
+
+        :param job_name: The name of the job to get the parents for
+        :return parents: The list of parent job names
+        """
+
+    @abstractmethod
+    def get_children(self, job_name: str) -> List[str]:
+        """
+        Get the child jobs of a given job
+
+        :param job_name: The name of the job to get the children for
+        :return children: The list of child job names
+        """
+
 
 class ExperimentStructureSQLRepository(ExperimentStructureRepository):
     def __init__(self, expid: str, engine: Engine, table: Table):
@@ -40,6 +58,18 @@ class ExperimentStructureSQLRepository(ExperimentStructureRepository):
         return [
             ExperimentStructureModel(e_from=row.e_from, e_to=row.e_to) for row in result
         ]
+
+    def get_parents(self, job_name: str) -> List[str]:
+        with self.engine.connect() as conn:
+            statement = self.table.select().where(self.table.c.e_to == job_name)
+            result = conn.execute(statement).all()
+        return [row.e_from for row in result]
+
+    def get_children(self, job_name: str) -> List[str]:
+        with self.engine.connect() as conn:
+            statement = self.table.select().where(self.table.c.e_from == job_name)
+            result = conn.execute(statement).all()
+        return [row.e_to for row in result]
 
 
 def create_experiment_structure_repository(expid: str) -> ExperimentStructureRepository:

--- a/autosubmit_api/repositories/job_data.py
+++ b/autosubmit_api/repositories/job_data.py
@@ -65,6 +65,12 @@ class ExperimentJobDataRepository(ABC):
         """
 
     @abstractmethod
+    def get_last_job_data_by_name(self, job_name: str) -> ExperimentJobDataModel:
+        """
+        Gets last job data of a specific job name
+        """
+
+    @abstractmethod
     def get_all(self) -> List[ExperimentJobDataModel]:
         """
         Gets all job data
@@ -140,6 +146,24 @@ class ExperimentJobDataSQLRepository(ExperimentJobDataRepository):
             ExperimentJobDataModel.model_validate(row, from_attributes=True)
             for row in result
         ]
+
+    def get_last_job_data_by_name(self, job_name: str):
+        with self.engine.connect() as conn:
+            statement = (
+                self.table.select()
+                .where(
+                    (self.table.c.job_name == job_name),
+                    (self.table.c.rowtype >= 2),
+                    (self.table.c.last == 1),
+                )
+                .order_by(self.table.c.counter.desc())
+            )
+            result = conn.execute(statement).first()
+
+        if result:
+            return ExperimentJobDataModel.model_validate(result, from_attributes=True)
+        else:
+            raise ValueError(f"No job data found for job name: {job_name}")
 
     def get_all(self):
         with self.engine.connect() as conn:

--- a/autosubmit_api/repositories/job_packages.py
+++ b/autosubmit_api/repositories/job_packages.py
@@ -37,7 +37,7 @@ class JobPackagesSQLRepository(JobPackagesRepository):
         self.engine = engine
         self.table = table
 
-    def get_all(self):
+    def get_all(self) -> List[JobPackageModel]:
         with self.engine.connect() as conn:
             statement = self.table.select()
             result = conn.execute(statement).all()
@@ -50,7 +50,7 @@ class JobPackagesSQLRepository(JobPackagesRepository):
             for row in result
         ]
 
-    def get_by_job_name(self, job_name: str):
+    def get_by_job_name(self, job_name: str) -> List[JobPackageModel]:
         with self.engine.connect() as conn:
             statement = self.table.select().where(self.table.c.job_name == job_name)
             result = conn.execute(statement).all()
@@ -62,6 +62,7 @@ class JobPackagesSQLRepository(JobPackagesRepository):
             )
             for row in result
         ]
+
 
 def create_job_packages_repository(expid: str, wrapper=False) -> JobPackagesRepository:
     """

--- a/autosubmit_api/repositories/job_packages.py
+++ b/autosubmit_api/repositories/job_packages.py
@@ -25,6 +25,12 @@ class JobPackagesRepository(ABC):
         Get all job packages.
         """
 
+    @abstractmethod
+    def get_by_job_name(self, job_name: str) -> List[JobPackageModel]:
+        """
+        Get the job packages for a given job name.
+        """
+
 
 class JobPackagesSQLRepository(JobPackagesRepository):
     def __init__(self, engine: Engine, table: Table):
@@ -44,6 +50,18 @@ class JobPackagesSQLRepository(JobPackagesRepository):
             for row in result
         ]
 
+    def get_by_job_name(self, job_name: str):
+        with self.engine.connect() as conn:
+            statement = self.table.select().where(self.table.c.job_name == job_name)
+            result = conn.execute(statement).all()
+        return [
+            JobPackageModel(
+                exp_id=row.exp_id,
+                package_name=row.package_name,
+                job_name=row.job_name,
+            )
+            for row in result
+        ]
 
 def create_job_packages_repository(expid: str, wrapper=False) -> JobPackagesRepository:
     """

--- a/autosubmit_api/repositories/jobs.py
+++ b/autosubmit_api/repositories/jobs.py
@@ -36,6 +36,12 @@ class JobsRepository(ABC):
         Gets the last modified UNIX timestamp of the jobs
         """
 
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[JobData]:
+        """
+        Gets a job by its name
+        """
+
 
 class JobsPklRepository(JobsRepository):
     def __init__(self, expid: str) -> None:
@@ -67,6 +73,29 @@ class JobsPklRepository(JobsRepository):
 
     def get_last_modified_timestamp(self) -> int:
         return self.pkl_reader.get_modified_time()
+
+    def get_by_name(self, name: str) -> Optional[JobData]:
+        """
+        Gets a job by its name from pkl file
+        """
+        pkl_content = self.pkl_reader.parse_job_list()
+        for job in pkl_content:
+            if job.name == name:
+                return JobData(
+                    id=job.id,
+                    name=job.name,
+                    status=job.status,
+                    priority=job.priority,
+                    section=job.section,
+                    date=job.date,
+                    member=job.member,
+                    chunk=job.chunk,
+                    out_path_local=job.out_path_local,
+                    err_path_local=job.err_path_local,
+                    out_path_remote=job.out_path_remote,
+                    err_path_remote=job.err_path_remote,
+                )
+        return None
 
 
 def create_jobs_repository(expid: str) -> JobsRepository:

--- a/autosubmit_api/repositories/jobs.py
+++ b/autosubmit_api/repositories/jobs.py
@@ -42,6 +42,12 @@ class JobsRepository(ABC):
         Gets a job by its name
         """
 
+    @abstractmethod
+    def get_by_names(self, names: List[str]) -> List[JobData]:
+        """
+        Gets jobs matching any of the given names
+        """
+
 
 class JobsPklRepository(JobsRepository):
     def __init__(self, expid: str) -> None:
@@ -96,6 +102,31 @@ class JobsPklRepository(JobsRepository):
                     err_path_remote=job.err_path_remote,
                 )
         return None
+
+    def get_by_names(self, names: List[str]) -> List[JobData]:
+        """
+        Gets all jobs whose names are in the given list, reading the pkl once.
+        """
+        name_set = set(names)
+        pkl_content = self.pkl_reader.parse_job_list()
+        return [
+            JobData(
+                id=job.id,
+                name=job.name,
+                status=job.status,
+                priority=job.priority,
+                section=job.section,
+                date=job.date,
+                member=job.member,
+                chunk=job.chunk,
+                out_path_local=job.out_path_local,
+                err_path_local=job.err_path_local,
+                out_path_remote=job.out_path_remote,
+                err_path_remote=job.err_path_remote,
+            )
+            for job in pkl_content
+            if job.name in name_set
+        ]
 
 
 def create_jobs_repository(expid: str) -> JobsRepository:

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -197,7 +197,7 @@ async def get_experiment_jobs(
     except Exception as exc:
         error_message = "Error while reading the job list"
         logger.error(error_message + f": {exc}")
-        logger.error(traceback.print_exc())
+        logger.error(traceback.format_exc())
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
         )
@@ -425,7 +425,6 @@ class JobDetailResponse(BaseModel):
     date: Optional[str] = None
     member: Optional[str] = None
     chunk: Optional[int] = None
-    section: Optional[str] = None
     # split: Optional[str] = None
     out_path_local: Optional[str] = None
     err_path_local: Optional[str] = None
@@ -468,6 +467,12 @@ async def get_experiment_job_detail(
         job_list_repo = create_jobs_repository(expid)
         current_job = job_list_repo.get_by_name(job_name)
 
+        if not current_job:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail=f"Job with name '{job_name}' not found in experiment '{expid}'",
+            )
+
         response = JobDetailResponse(
             name=current_job.name,
             status=Status.VALUE_TO_KEY.get(current_job.status, Status.UNKNOWN),
@@ -503,18 +508,14 @@ async def get_experiment_job_detail(
             else None
         )
 
+    except HTTPException:
+        raise
     except Exception as exc:
         error_message = "Error while reading the job list"
         logger.error(error_message + f": {exc}")
-        logger.error(traceback.print_exc())
+        logger.error(traceback.format_exc())
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
-        )
-
-    if not current_job:
-        raise HTTPException(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail=f"Job with name '{job_name}' not found in experiment '{expid}'",
         )
 
     # Get data from the historical DB

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -14,16 +14,16 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from autosubmit_api.auth import auth_token_dependency
-from autosubmit_api.builders.configuration_facade_builder import (
-    AutosubmitConfigurationFacadeBuilder,
-    ConfigurationFacadeDirector,
-)
 from autosubmit_api.builders.experiment_builder import ExperimentBuilder
 from autosubmit_api.builders.experiment_history_builder import (
     ExperimentHistoryBuilder,
     ExperimentHistoryDirector,
 )
 from autosubmit_api.common.utils import Status, timestamp_to_datetime_format
+from autosubmit_api.components.jobs.job_detail import (
+    JobDetailRetriever,
+    JobNotFoundError,
+)
 from autosubmit_api.components.jobs.utils import get_fixed_experiment_times
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.config.confConfigStrategy import confConfigStrategy
@@ -45,12 +45,9 @@ from autosubmit_api.models.responses import (
 )
 from autosubmit_api.persistance.experiment import ExperimentPaths
 from autosubmit_api.persistance.job_package_reader import JobPackageReader
-from autosubmit_api.repositories.experiment_run import create_experiment_run_repository
 from autosubmit_api.repositories.experiment_structure import (
     create_experiment_structure_repository,
 )
-from autosubmit_api.repositories.job_data import create_experiment_job_data_repository
-from autosubmit_api.repositories.job_packages import create_job_packages_repository
 from autosubmit_api.repositories.jobs import create_jobs_repository
 from autosubmit_api.repositories.join.experiment_join import (
     create_experiment_join_repository,
@@ -429,9 +426,9 @@ class JobDetailResponse(BaseModel):
     out_path_local: Optional[str] = None
     err_path_local: Optional[str] = None
     # From config
-    platform: Optional[str] = None
     chunk_size: Optional[int] = None
     chunk_unit: Optional[str] = None
+    platform: Optional[str] = None
     # From historical DB
     remote_id: Optional[int] = None
     qos: Optional[str] = None
@@ -441,16 +438,8 @@ class JobDetailResponse(BaseModel):
     start: Optional[str] = None
     finish: Optional[str] = None
     wallclock: Optional[str] = None
-    # From structure DB
-    # parents: Optional[int] = None
-    # children: Optional[int] = None
-
-    # # Calculated fields
-    processing_elements: Optional[str] = None
-    # run_time: Optional[str] = None
-    # queue_time: Optional[str] = None
-    # SYPD: Optional[float] = None  # Simulated Years Per Day
-    # ASYPD: Optional[float] = None  # Average Simulated Years Per Day
+    # Wrapper data
+    last_wrapper: Optional[str] = None
 
 
 @router.get("/{expid}/jobs/{job_name}", name="Get experiment job detail")
@@ -462,32 +451,40 @@ async def get_experiment_job_detail(
     """
     Get the details of a specific job of an experiment
     """
-    # Read the pkl
+    # Get the latest job details from the retriever
     try:
-        job_list_repo = create_jobs_repository(expid)
-        current_job = job_list_repo.get_by_name(job_name)
-
-        if not current_job:
-            raise HTTPException(
-                status_code=HTTPStatus.NOT_FOUND,
-                detail=f"Job with name '{job_name}' not found in experiment '{expid}'",
-            )
-
-        response = JobDetailResponse(
-            name=current_job.name,
-            status=Status.VALUE_TO_KEY.get(current_job.status, Status.UNKNOWN),
-            section=current_job.section,
-            date=current_job.date.strftime("%Y%m%d") if current_job.date else None,
-            member=current_job.member,
-            chunk=current_job.chunk,
+        job_detail_retriever = JobDetailRetriever(expid, job_name)
+        job_detail_retriever.load_data()
+    except JobNotFoundError:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Job with name '{job_name}' not found in experiment '{expid}'",
         )
-        exp_paths = ExperimentPaths(expid)
+    except Exception:
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Error while retrieving job details",
+        )
 
-        job_logs_out = []
-        job_logs_err = []
-        if current_job.status in [Status.COMPLETED, Status.FAILED]:
+    # Try to get fixed submit, start and finish times for the job
+    submit, start, finish = None, None, None
+    try:
+        submit, start, finish = get_fixed_experiment_times(
+            expid, job_detail_retriever._job_data, job_detail_retriever._historical_data
+        )
+    except Exception:
+        logger.warning("Error while getting fixed experiment times")
+        logger.warning(traceback.format_exc())
+
+    # Get the latest logs for the job, if it has finished
+    exp_paths = ExperimentPaths(expid)
+    job_logs_out = []
+    job_logs_err = []
+    try:
+        if job_detail_retriever.status_code in [Status.COMPLETED, Status.FAILED]:
             for f in os.listdir(exp_paths.tmp_log_dir):
-                if f.startswith(current_job.name):
+                if f.startswith(job_detail_retriever.name):
                     if f.endswith(".out"):
                         job_logs_out.append(f)
                     elif f.endswith(".err"):
@@ -496,97 +493,44 @@ async def get_experiment_job_detail(
         # Sort logs by time in the name, assuming the format is <job_name>.<timestamp>.[out|err]
         job_logs_out.sort()
         job_logs_err.sort()
-
-        response.out_path_local = (
-            os.path.join(exp_paths.tmp_log_dir, job_logs_out[-1])
-            if job_logs_out
-            else None
-        )
-        response.err_path_local = (
-            os.path.join(exp_paths.tmp_log_dir, job_logs_err[-1])
-            if job_logs_err
-            else None
-        )
-
-    except HTTPException:
-        raise
-    except Exception as exc:
-        error_message = "Error while reading the job list"
-        logger.error(error_message + f": {exc}")
-        logger.error(traceback.format_exc())
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
-        )
-
-    # Get data from the historical DB
-    try:
-        run_repo = create_experiment_run_repository(expid)
-        latest_run = run_repo.get_last_run()
-
-        response.chunk_size = latest_run.chunk_size
-        response.chunk_unit = latest_run.chunk_unit
     except Exception:
-        logger.warning("Error while getting the latest run from the historical DB")
+        logger.warning("Error while retrieving job logs")
         logger.warning(traceback.format_exc())
 
-    # Get data from the historical DB
-    try:
-        job_data_repo = create_experiment_job_data_repository(expid)
-        job_last_data = job_data_repo.get_last_job_data_by_name(job_name)
+    # Build the response
+    response = JobDetailResponse(
+        name=job_name, status=Status.VALUE_TO_KEY.get(Status.UNKNOWN)
+    )
 
-        response.platform = job_last_data.platform
-        response.remote_id = job_last_data.job_id
-        response.qos = job_last_data.qos
-        response.processors = job_last_data.ncpus  # Requested PROCESSORS
-        response.wallclock = job_last_data.wallclock
-        response.workflow_commit = job_last_data.workflow_commit
-
-        logger.debug(f"Job last data from historical DB: {job_last_data}")
-
-        submit, start, finish = get_fixed_experiment_times(
-            expid, current_job, job_last_data
-        )
-        response.submit = timestamp_to_datetime_format(submit)
-        response.start = timestamp_to_datetime_format(start)
-        response.finish = timestamp_to_datetime_format(finish)
-    except Exception:
-        logger.warning("Error while getting the job data from the historical DB")
-        logger.warning(traceback.format_exc())
-
-    # Get data from config, to correct data
-    try:
-        autosubmit_config_facade = ConfigurationFacadeDirector(
-            AutosubmitConfigurationFacadeBuilder(expid)
-        ).build_autosubmit_configuration_facade()
-
-        section_platform = autosubmit_config_facade.get_section_platform(
-            current_job.section
-        )
-        if section_platform:
-            response.platform = section_platform
-        if autosubmit_config_facade.chunk_size:
-            response.chunk_size = autosubmit_config_facade.chunk_size
-        if autosubmit_config_facade.chunk_unit:
-            response.chunk_unit = autosubmit_config_facade.chunk_unit
-        workflow_commit = autosubmit_config_facade.get_workflow_commit()
-        if workflow_commit:
-            response.workflow_commit = workflow_commit
-        section_qos = autosubmit_config_facade.get_section_qos(current_job.section)
-        if section_qos:
-            response.qos = section_qos
-        section_processors = autosubmit_config_facade.get_section_processors(
-            current_job.section
-        )
-        if section_processors:
-            response.processors = section_processors
-        section_wallclock = autosubmit_config_facade.get_section_wallclock(
-            current_job.section
-        )
-        if section_wallclock:
-            response.wallclock = section_wallclock
-    except Exception:
-        logger.warning("Error while building the configuration facade")
-        logger.warning(traceback.format_exc())
+    response.status = Status.VALUE_TO_KEY.get(
+        job_detail_retriever.status_code, Status.UNKNOWN
+    )
+    response.section = job_detail_retriever.section
+    response.date = (
+        job_detail_retriever.date.strftime("%Y%m%d")
+        if job_detail_retriever.date
+        else None
+    )
+    response.member = job_detail_retriever.member
+    response.chunk = job_detail_retriever.chunk
+    response.out_path_local = (
+        os.path.join(exp_paths.tmp_log_dir, job_logs_out[-1]) if job_logs_out else None
+    )
+    response.err_path_local = (
+        os.path.join(exp_paths.tmp_log_dir, job_logs_err[-1]) if job_logs_err else None
+    )
+    response.chunk_size = job_detail_retriever.chunk_size
+    response.chunk_unit = job_detail_retriever.chunk_unit
+    response.platform = job_detail_retriever.platform
+    response.remote_id = job_detail_retriever.remote_id
+    response.qos = job_detail_retriever.qos
+    response.processors = job_detail_retriever.processors
+    response.wallclock = job_detail_retriever.wallclock
+    response.workflow_commit = job_detail_retriever.workflow_commit
+    response.submit = timestamp_to_datetime_format(submit)
+    response.start = timestamp_to_datetime_format(start)
+    response.finish = timestamp_to_datetime_format(finish)
+    response.last_wrapper = job_detail_retriever.last_wrapper
 
     return response
 
@@ -671,27 +615,3 @@ async def get_experiment_job_children(
             logger.warning(traceback.format_exc())
 
     return {"children": child_items}
-
-
-@router.get("/{expid}/jobs/{job_name}/wrappers", name="Get experiment job wrappers")
-async def get_experiment_job_wrappers(
-    expid: str,
-    job_name: str,
-    user_id: Optional[str] = Depends(auth_token_dependency()),
-) -> Dict:
-    """
-    Get the wrappers of a specific job of an experiment
-    """
-    try:
-        job_package_repo = create_job_packages_repository(expid)
-        job_packages = job_package_repo.get_by_job_name(job_name)
-        wrappers = [jp.package_name for jp in job_packages]
-    except Exception as exc:
-        error_message = "Error while reading the job packages"
-        logger.error(error_message + f": {exc}")
-        logger.error(traceback.format_exc())
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
-        )
-
-    return {"wrappers": [{"wrapper_name": wrapper} for wrapper in wrappers]}

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -46,7 +46,11 @@ from autosubmit_api.models.responses import (
 from autosubmit_api.persistance.experiment import ExperimentPaths
 from autosubmit_api.persistance.job_package_reader import JobPackageReader
 from autosubmit_api.repositories.experiment_run import create_experiment_run_repository
+from autosubmit_api.repositories.experiment_structure import (
+    create_experiment_structure_repository,
+)
 from autosubmit_api.repositories.job_data import create_experiment_job_data_repository
+from autosubmit_api.repositories.job_packages import create_job_packages_repository
 from autosubmit_api.repositories.jobs import create_jobs_repository
 from autosubmit_api.repositories.join.experiment_join import (
     create_experiment_join_repository,
@@ -584,3 +588,73 @@ async def get_experiment_job_detail(
         logger.warning(traceback.format_exc())
 
     return response
+
+
+@router.get("/{expid}/jobs/{job_name}/parents", name="Get experiment job parents")
+async def get_experiment_job_parents(
+    expid: str,
+    job_name: str,
+    user_id: Optional[str] = Depends(auth_token_dependency()),
+) -> Dict:
+    """
+    Get the parents of a specific job of an experiment
+    """
+    try:
+        structure_repo = create_experiment_structure_repository(expid)
+        parents = structure_repo.get_parents(job_name)
+    except Exception as exc:
+        error_message = "Error while reading the experiment structure"
+        logger.error(error_message + f": {exc}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
+        )
+
+    return {"parents": [{"job_name": parent} for parent in parents]}
+
+
+@router.get("/{expid}/jobs/{job_name}/children", name="Get experiment job children")
+async def get_experiment_job_children(
+    expid: str,
+    job_name: str,
+    user_id: Optional[str] = Depends(auth_token_dependency()),
+) -> Dict:
+    """
+    Get the children of a specific job of an experiment
+    """
+    try:
+        structure_repo = create_experiment_structure_repository(expid)
+        children = structure_repo.get_children(job_name)
+    except Exception as exc:
+        error_message = "Error while reading the experiment structure"
+        logger.error(error_message + f": {exc}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
+        )
+
+    return {"children": [{"job_name": child} for child in children]}
+
+
+@router.get("/{expid}/jobs/{job_name}/wrappers", name="Get experiment job wrappers")
+async def get_experiment_job_wrappers(
+    expid: str,
+    job_name: str,
+    user_id: Optional[str] = Depends(auth_token_dependency()),
+) -> Dict:
+    """
+    Get the wrappers of a specific job of an experiment
+    """
+    try:
+        job_package_repo = create_job_packages_repository(expid)
+        job_packages = job_package_repo.get_by_job_name(job_name)
+        wrappers = [jp.package_name for jp in job_packages]
+    except Exception as exc:
+        error_message = "Error while reading the job packages"
+        logger.error(error_message + f": {exc}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
+        )
+
+    return {"wrappers": [{"wrapper_name": wrapper} for wrapper in wrappers]}

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import math
+import os
 import traceback
 from collections import deque
 from datetime import datetime, timezone
@@ -42,6 +43,7 @@ from autosubmit_api.models.responses import (
     ExperimentsSearchResponse,
     ExperimentWrappersResponse,
 )
+from autosubmit_api.persistance.experiment import ExperimentPaths
 from autosubmit_api.persistance.job_package_reader import JobPackageReader
 from autosubmit_api.repositories.experiment_run import create_experiment_run_repository
 from autosubmit_api.repositories.job_data import create_experiment_job_data_repository
@@ -469,9 +471,34 @@ async def get_experiment_job_detail(
             date=current_job.date.strftime("%Y%m%d") if current_job.date else None,
             member=current_job.member,
             chunk=current_job.chunk,
-            out_path_local=current_job.out_path_local,
-            err_path_local=current_job.err_path_local,
         )
+        exp_paths = ExperimentPaths(expid)
+
+        job_logs_out = []
+        job_logs_err = []
+        if current_job.status in [Status.COMPLETED, Status.FAILED]:
+            for f in os.listdir(exp_paths.tmp_log_dir):
+                if f.startswith(current_job.name):
+                    if f.endswith(".out"):
+                        job_logs_out.append(f)
+                    elif f.endswith(".err"):
+                        job_logs_err.append(f)
+
+        # Sort logs by time in the name, assuming the format is <job_name>.<timestamp>.[out|err]
+        job_logs_out.sort()
+        job_logs_err.sort()
+
+        response.out_path_local = (
+            os.path.join(exp_paths.tmp_log_dir, job_logs_out[-1])
+            if job_logs_out
+            else None
+        )
+        response.err_path_local = (
+            os.path.join(exp_paths.tmp_log_dir, job_logs_err[-1])
+            if job_logs_err
+            else None
+        )
+
     except Exception as exc:
         error_message = "Error while reading the job list"
         logger.error(error_message + f": {exc}")
@@ -505,13 +532,15 @@ async def get_experiment_job_detail(
         response.platform = job_last_data.platform
         response.remote_id = job_last_data.job_id
         response.qos = job_last_data.qos
-        response.processors = job_last_data.ncpus # Requested PROCESSORS
+        response.processors = job_last_data.ncpus  # Requested PROCESSORS
         response.wallclock = job_last_data.wallclock
         response.workflow_commit = job_last_data.workflow_commit
 
         logger.debug(f"Job last data from historical DB: {job_last_data}")
 
-        submit, start, finish = get_fixed_experiment_times(expid, current_job, job_last_data)
+        submit, start, finish = get_fixed_experiment_times(
+            expid, current_job, job_last_data
+        )
         response.submit = timestamp_to_datetime_format(submit)
         response.start = timestamp_to_datetime_format(start)
         response.finish = timestamp_to_datetime_format(finish)
@@ -522,19 +551,36 @@ async def get_experiment_job_detail(
     # Get data from config, to correct data
     try:
         autosubmit_config_facade = ConfigurationFacadeDirector(
-                    AutosubmitConfigurationFacadeBuilder(expid)
-                ).build_autosubmit_configuration_facade()
-        
-        response.platform = autosubmit_config_facade.get_section_platform(current_job.section)
-        response.chunk_size = autosubmit_config_facade.chunk_size
-        response.chunk_unit = autosubmit_config_facade.chunk_unit
-        response.workflow_commit = autosubmit_config_facade.get_workflow_commit()
-        response.qos = autosubmit_config_facade.get_section_qos(current_job.section)
-        response.processors = autosubmit_config_facade.get_section_processors(current_job.section)
-        response.wallclock = autosubmit_config_facade.get_section_wallclock(current_job.section)
+            AutosubmitConfigurationFacadeBuilder(expid)
+        ).build_autosubmit_configuration_facade()
+
+        section_platform = autosubmit_config_facade.get_section_platform(
+            current_job.section
+        )
+        if section_platform:
+            response.platform = section_platform
+        if autosubmit_config_facade.chunk_size:
+            response.chunk_size = autosubmit_config_facade.chunk_size
+        if autosubmit_config_facade.chunk_unit:
+            response.chunk_unit = autosubmit_config_facade.chunk_unit
+        workflow_commit = autosubmit_config_facade.get_workflow_commit()
+        if workflow_commit:
+            response.workflow_commit = workflow_commit
+        section_qos = autosubmit_config_facade.get_section_qos(current_job.section)
+        if section_qos:
+            response.qos = section_qos
+        section_processors = autosubmit_config_facade.get_section_processors(
+            current_job.section
+        )
+        if section_processors:
+            response.processors = section_processors
+        section_wallclock = autosubmit_config_facade.get_section_wallclock(
+            current_job.section
+        )
+        if section_wallclock:
+            response.wallclock = section_wallclock
     except Exception:
         logger.warning("Error while building the configuration facade")
         logger.warning(traceback.format_exc())
-    
 
     return response

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import math
 import os
+import re
 import traceback
 from collections import deque
 from datetime import datetime, timezone
@@ -24,7 +25,6 @@ from autosubmit_api.components.jobs.job_detail import (
     JobDetailRetriever,
     JobNotFoundError,
 )
-from autosubmit_api.components.jobs.utils import get_fixed_experiment_times
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.config.confConfigStrategy import confConfigStrategy
 from autosubmit_api.config.config_common import AutosubmitConfigResolver
@@ -467,28 +467,25 @@ async def get_experiment_job_detail(
             detail="Error while retrieving job details",
         )
 
-    # Try to get fixed submit, start and finish times for the job
-    submit, start, finish = None, None, None
-    try:
-        submit, start, finish = get_fixed_experiment_times(
-            expid, job_detail_retriever._job_data, job_detail_retriever._historical_data
-        )
-    except Exception:
-        logger.warning("Error while getting fixed experiment times")
-        logger.warning(traceback.format_exc())
-
     # Get the latest logs for the job, if it has finished
     exp_paths = ExperimentPaths(expid)
     job_logs_out = []
     job_logs_err = []
     try:
         if job_detail_retriever.status_code in [Status.COMPLETED, Status.FAILED]:
-            for f in os.listdir(exp_paths.tmp_log_dir):
-                if f.startswith(job_detail_retriever.name):
-                    if f.endswith(".out"):
-                        job_logs_out.append(f)
-                    elif f.endswith(".err"):
-                        job_logs_err.append(f)
+            for f in os.scandir(exp_paths.tmp_log_dir):
+                if not f.is_file():
+                    continue
+                if re.match(
+                    rf"^{re.escape(job_detail_retriever.name)}.*\.out(\.xz|\.gz)?$",
+                    f.name,
+                ):
+                    job_logs_out.append(f.name)
+                elif re.match(
+                    rf"^{re.escape(job_detail_retriever.name)}.*\.err(\.xz|\.gz)?$",
+                    f.name,
+                ):
+                    job_logs_err.append(f.name)
 
         # Sort logs by time in the name, assuming the format is <job_name>.<timestamp>.[out|err]
         job_logs_out.sort()
@@ -505,32 +502,34 @@ async def get_experiment_job_detail(
         ),
     )
 
-    response.section = job_detail_retriever.section
-    response.date = (
-        job_detail_retriever.date.strftime("%Y%m%d")
-        if job_detail_retriever.date
-        else None
+    response = response.model_copy(
+        update={
+            "section": job_detail_retriever.section,
+            "date": job_detail_retriever.date.strftime("%Y%m%d")
+            if job_detail_retriever.date
+            else None,
+            "member": job_detail_retriever.member,
+            "chunk": job_detail_retriever.chunk,
+            "out_path_local": os.path.join(exp_paths.tmp_log_dir, job_logs_out[-1])
+            if job_logs_out
+            else None,
+            "err_path_local": os.path.join(exp_paths.tmp_log_dir, job_logs_err[-1])
+            if job_logs_err
+            else None,
+            "chunk_size": job_detail_retriever.chunk_size,
+            "chunk_unit": job_detail_retriever.chunk_unit,
+            "platform": job_detail_retriever.platform,
+            "remote_id": job_detail_retriever.remote_id,
+            "qos": job_detail_retriever.qos,
+            "processors": job_detail_retriever.processors,
+            "wallclock": job_detail_retriever.wallclock,
+            "workflow_commit": job_detail_retriever.workflow_commit,
+            "submit": timestamp_to_datetime_format(job_detail_retriever.submit),
+            "start": timestamp_to_datetime_format(job_detail_retriever.start),
+            "finish": timestamp_to_datetime_format(job_detail_retriever.finish),
+            "last_wrapper": job_detail_retriever.last_wrapper,
+        }
     )
-    response.member = job_detail_retriever.member
-    response.chunk = job_detail_retriever.chunk
-    response.out_path_local = (
-        os.path.join(exp_paths.tmp_log_dir, job_logs_out[-1]) if job_logs_out else None
-    )
-    response.err_path_local = (
-        os.path.join(exp_paths.tmp_log_dir, job_logs_err[-1]) if job_logs_err else None
-    )
-    response.chunk_size = job_detail_retriever.chunk_size
-    response.chunk_unit = job_detail_retriever.chunk_unit
-    response.platform = job_detail_retriever.platform
-    response.remote_id = job_detail_retriever.remote_id
-    response.qos = job_detail_retriever.qos
-    response.processors = job_detail_retriever.processors
-    response.wallclock = job_detail_retriever.wallclock
-    response.workflow_commit = job_detail_retriever.workflow_commit
-    response.submit = timestamp_to_datetime_format(submit)
-    response.start = timestamp_to_datetime_format(start)
-    response.finish = timestamp_to_datetime_format(finish)
-    response.last_wrapper = job_detail_retriever.last_wrapper
 
     return response
 

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -497,9 +497,7 @@ async def get_experiment_job_detail(
     # Build the response
     response = JobDetailResponse(
         name=job_name,
-        status=Status.VALUE_TO_KEY.get(
-            job_detail_retriever.status_code, Status.UNKNOWN
-        ),
+        status=Status.VALUE_TO_KEY.get(job_detail_retriever.status_code, "UNKNOWN"),
     )
 
     response = response.model_copy(
@@ -563,7 +561,7 @@ async def get_experiment_job_parents(
             job_list_repo = create_jobs_repository(expid)
             jobs_data = job_list_repo.get_by_names(parents)
             status_map = {
-                job.name: Status.VALUE_TO_KEY.get(job.status, Status.UNKNOWN)
+                job.name: Status.VALUE_TO_KEY.get(job.status, "UNKNOWN")
                 for job in jobs_data
             }
             for item in parent_items:
@@ -604,7 +602,7 @@ async def get_experiment_job_children(
             job_list_repo = create_jobs_repository(expid)
             jobs_data = job_list_repo.get_by_names(children)
             status_map = {
-                job.name: Status.VALUE_TO_KEY.get(job.status, Status.UNKNOWN)
+                job.name: Status.VALUE_TO_KEY.get(job.status, "UNKNOWN")
                 for job in jobs_data
             }
             for item in child_items:

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -499,12 +499,12 @@ async def get_experiment_job_detail(
 
     # Build the response
     response = JobDetailResponse(
-        name=job_name, status=Status.VALUE_TO_KEY.get(Status.UNKNOWN)
+        name=job_name,
+        status=Status.VALUE_TO_KEY.get(
+            job_detail_retriever.status_code, Status.UNKNOWN
+        ),
     )
 
-    response.status = Status.VALUE_TO_KEY.get(
-        job_detail_retriever.status_code, Status.UNKNOWN
-    )
     response.section = job_detail_retriever.section
     response.date = (
         job_detail_retriever.date.strftime("%Y%m%d")

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -595,10 +595,12 @@ async def get_experiment_job_detail(
 async def get_experiment_job_parents(
     expid: str,
     job_name: str,
+    include_status: bool = False,
     user_id: Optional[str] = Depends(auth_token_dependency()),
 ) -> Dict:
     """
-    Get the parents of a specific job of an experiment
+    Get the parents of a specific job of an experiment.
+    Set include_status=true to also return the current status of each parent job.
     """
     try:
         structure_repo = create_experiment_structure_repository(expid)
@@ -611,17 +613,35 @@ async def get_experiment_job_parents(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
         )
 
-    return {"parents": [{"job_name": parent} for parent in parents]}
+    parent_items = [{"job_name": parent} for parent in parents]
+
+    if include_status and parents:
+        try:
+            job_list_repo = create_jobs_repository(expid)
+            jobs_data = job_list_repo.get_by_names(parents)
+            status_map = {
+                job.name: Status.VALUE_TO_KEY.get(job.status, Status.UNKNOWN)
+                for job in jobs_data
+            }
+            for item in parent_items:
+                item["status"] = status_map.get(item["job_name"])
+        except Exception as exc:
+            logger.warning(f"Error while fetching parent job statuses: {exc}")
+            logger.warning(traceback.format_exc())
+
+    return {"parents": parent_items}
 
 
 @router.get("/{expid}/jobs/{job_name}/children", name="Get experiment job children")
 async def get_experiment_job_children(
     expid: str,
     job_name: str,
+    include_status: bool = False,
     user_id: Optional[str] = Depends(auth_token_dependency()),
 ) -> Dict:
     """
     Get the children of a specific job of an experiment
+    Set include_status=true to also return the current status of each child job.
     """
     try:
         structure_repo = create_experiment_structure_repository(expid)
@@ -634,7 +654,23 @@ async def get_experiment_job_children(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
         )
 
-    return {"children": [{"job_name": child} for child in children]}
+    child_items = [{"job_name": child} for child in children]
+
+    if include_status and children:
+        try:
+            job_list_repo = create_jobs_repository(expid)
+            jobs_data = job_list_repo.get_by_names(children)
+            status_map = {
+                job.name: Status.VALUE_TO_KEY.get(job.status, Status.UNKNOWN)
+                for job in jobs_data
+            }
+            for item in child_items:
+                item["status"] = status_map.get(item["job_name"])
+        except Exception as exc:
+            logger.warning(f"Error while fetching child job statuses: {exc}")
+            logger.warning(traceback.format_exc())
+
+    return {"children": child_items}
 
 
 @router.get("/{expid}/jobs/{job_name}/wrappers", name="Get experiment job wrappers")

--- a/autosubmit_api/routers/v4/experiments.py
+++ b/autosubmit_api/routers/v4/experiments.py
@@ -10,14 +10,20 @@ from typing import Annotated, Any, Dict, List, Literal, Optional
 from bscearth.utils.config_parser import ConfigParserFactory
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from autosubmit_api.auth import auth_token_dependency
+from autosubmit_api.builders.configuration_facade_builder import (
+    AutosubmitConfigurationFacadeBuilder,
+    ConfigurationFacadeDirector,
+)
 from autosubmit_api.builders.experiment_builder import ExperimentBuilder
 from autosubmit_api.builders.experiment_history_builder import (
     ExperimentHistoryBuilder,
     ExperimentHistoryDirector,
 )
-from autosubmit_api.common.utils import Status
+from autosubmit_api.common.utils import Status, timestamp_to_datetime_format
+from autosubmit_api.components.jobs.utils import get_fixed_experiment_times
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.config.confConfigStrategy import confConfigStrategy
 from autosubmit_api.config.config_common import AutosubmitConfigResolver
@@ -37,6 +43,8 @@ from autosubmit_api.models.responses import (
     ExperimentWrappersResponse,
 )
 from autosubmit_api.persistance.job_package_reader import JobPackageReader
+from autosubmit_api.repositories.experiment_run import create_experiment_run_repository
+from autosubmit_api.repositories.job_data import create_experiment_job_data_repository
 from autosubmit_api.repositories.jobs import create_jobs_repository
 from autosubmit_api.repositories.join.experiment_join import (
     create_experiment_join_repository,
@@ -401,3 +409,132 @@ async def get_runs_with_user_metrics(
             for run_id in run_ids
         ]
     }
+
+
+class JobDetailResponse(BaseModel):
+    # From pkl
+    name: str
+    status: str
+    section: Optional[str] = None
+    date: Optional[str] = None
+    member: Optional[str] = None
+    chunk: Optional[int] = None
+    section: Optional[str] = None
+    # split: Optional[str] = None
+    out_path_local: Optional[str] = None
+    err_path_local: Optional[str] = None
+    # From config
+    platform: Optional[str] = None
+    chunk_size: Optional[int] = None
+    chunk_unit: Optional[str] = None
+    # From historical DB
+    remote_id: Optional[int] = None
+    qos: Optional[str] = None
+    workflow_commit: Optional[str] = None
+    processors: Optional[int] = None  # Requested ncpus
+    submit: Optional[str] = None
+    start: Optional[str] = None
+    finish: Optional[str] = None
+    wallclock: Optional[str] = None
+    # From structure DB
+    # parents: Optional[int] = None
+    # children: Optional[int] = None
+
+    # # Calculated fields
+    processing_elements: Optional[str] = None
+    # run_time: Optional[str] = None
+    # queue_time: Optional[str] = None
+    # SYPD: Optional[float] = None  # Simulated Years Per Day
+    # ASYPD: Optional[float] = None  # Average Simulated Years Per Day
+
+
+@router.get("/{expid}/jobs/{job_name}", name="Get experiment job detail")
+async def get_experiment_job_detail(
+    expid: str,
+    job_name: str,
+    user_id: Optional[str] = Depends(auth_token_dependency()),
+) -> JobDetailResponse:
+    """
+    Get the details of a specific job of an experiment
+    """
+    # Read the pkl
+    try:
+        job_list_repo = create_jobs_repository(expid)
+        current_job = job_list_repo.get_by_name(job_name)
+
+        response = JobDetailResponse(
+            name=current_job.name,
+            status=Status.VALUE_TO_KEY.get(current_job.status, Status.UNKNOWN),
+            section=current_job.section,
+            date=current_job.date.strftime("%Y%m%d") if current_job.date else None,
+            member=current_job.member,
+            chunk=current_job.chunk,
+            out_path_local=current_job.out_path_local,
+            err_path_local=current_job.err_path_local,
+        )
+    except Exception as exc:
+        error_message = "Error while reading the job list"
+        logger.error(error_message + f": {exc}")
+        logger.error(traceback.print_exc())
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=error_message
+        )
+
+    if not current_job:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Job with name '{job_name}' not found in experiment '{expid}'",
+        )
+
+    # Get data from the historical DB
+    try:
+        run_repo = create_experiment_run_repository(expid)
+        latest_run = run_repo.get_last_run()
+
+        response.chunk_size = latest_run.chunk_size
+        response.chunk_unit = latest_run.chunk_unit
+    except Exception:
+        logger.warning("Error while getting the latest run from the historical DB")
+        logger.warning(traceback.format_exc())
+
+    # Get data from the historical DB
+    try:
+        job_data_repo = create_experiment_job_data_repository(expid)
+        job_last_data = job_data_repo.get_last_job_data_by_name(job_name)
+
+        response.platform = job_last_data.platform
+        response.remote_id = job_last_data.job_id
+        response.qos = job_last_data.qos
+        response.processors = job_last_data.ncpus # Requested PROCESSORS
+        response.wallclock = job_last_data.wallclock
+        response.workflow_commit = job_last_data.workflow_commit
+
+        logger.debug(f"Job last data from historical DB: {job_last_data}")
+
+        submit, start, finish = get_fixed_experiment_times(expid, current_job, job_last_data)
+        response.submit = timestamp_to_datetime_format(submit)
+        response.start = timestamp_to_datetime_format(start)
+        response.finish = timestamp_to_datetime_format(finish)
+    except Exception:
+        logger.warning("Error while getting the job data from the historical DB")
+        logger.warning(traceback.format_exc())
+
+    # Get data from config, to correct data
+    try:
+        autosubmit_config_facade = ConfigurationFacadeDirector(
+                    AutosubmitConfigurationFacadeBuilder(expid)
+                ).build_autosubmit_configuration_facade()
+        
+        response.platform = autosubmit_config_facade.get_section_platform(current_job.section)
+        response.chunk_size = autosubmit_config_facade.chunk_size
+        response.chunk_unit = autosubmit_config_facade.chunk_unit
+        response.workflow_commit = autosubmit_config_facade.get_workflow_commit()
+        response.qos = autosubmit_config_facade.get_section_qos(current_job.section)
+        response.processors = autosubmit_config_facade.get_section_processors(current_job.section)
+        response.wallclock = autosubmit_config_facade.get_section_wallclock(current_job.section)
+    except Exception:
+        logger.warning("Error while building the configuration facade")
+        logger.warning(traceback.format_exc())
+    
+
+    return response

--- a/tests/test_endpoints_v4.py
+++ b/tests/test_endpoints_v4.py
@@ -371,6 +371,44 @@ class TestExperimentJobDetail:
             assert key in resp_obj
             assert resp_obj[key] == value
 
+    @pytest.mark.parametrize(
+        "expid, job_name, out, err",
+        [
+            (
+                "a3tb",
+                "a3tb_19930101_fc01_1_SIM",
+                "a3tb/tmp/LOG_a3tb/a3tb_19930101_fc01_1_SIM.20220315153049.out",
+                "a3tb/tmp/LOG_a3tb/a3tb_19930101_fc01_1_SIM.20220315153049.err",
+            ),
+            (
+                "a8qc",
+                "a8qc_20220630_000_1_CLEAN",
+                "a8qc/tmp/LOG_a8qc/a8qc_20220630_000_1_CLEAN.20250312185154.out.xz",
+                "a8qc/tmp/LOG_a8qc/a8qc_20220630_000_1_CLEAN.20250312185154.err.gz",
+            ),
+        ],
+    )
+    def test_job_detail_paths_local(
+        self,
+        fixture_fastapi_client: TestClient,
+        expid: str,
+        job_name: str,
+        out: str,
+        err: str,
+    ):
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name)
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert isinstance(resp_obj["out_path_local"], str) and resp_obj[
+            "out_path_local"
+        ].endswith(out)
+        assert isinstance(resp_obj["err_path_local"], str) and resp_obj[
+            "err_path_local"
+        ].endswith(err)
+
 
 class TestExperimentJobParents:
     endpoint = "/v4/experiments/{expid}/jobs/{job_name}/parents"

--- a/tests/test_endpoints_v4.py
+++ b/tests/test_endpoints_v4.py
@@ -10,6 +10,7 @@ import pytest
 from autosubmit_api import config
 from autosubmit_api.models.requests import PAGINATION_LIMIT_DEFAULT
 from autosubmit_api.repositories.runner_processes import RunnerProcessesDataModel
+from autosubmit_api.routers.v4.experiments import JobDetailResponse
 from tests.utils import custom_return_value
 
 
@@ -235,6 +236,282 @@ class TestExperimentJobs:
             assert isinstance(job, dict) and len(job.keys()) > 2
             assert isinstance(job["name"], str) and job["name"].startswith(expid)
             assert isinstance(job["status"], str)
+
+
+class TestExperimentJobDetail:
+    endpoint = "/v4/experiments/{expid}/jobs/{job_name}"
+
+    def test_job_not_found(self, fixture_fastapi_client: TestClient):
+        expid = "a003"
+        job_name = "a003_NONEXISTENT_JOB"
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name)
+        )
+
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+    def test_job_detail(self, fixture_fastapi_client: TestClient):
+        expid = "a003"
+        job_name = "a003_LOCAL_SETUP"
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name)
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert resp_obj["name"] == job_name
+        assert isinstance(resp_obj["status"], str)
+        for field in JobDetailResponse.model_fields:
+            assert field in resp_obj
+
+    @pytest.mark.parametrize(
+        "expid, job_name, expected",
+        [
+            (
+                "a003",
+                "a003_LOCAL_SETUP",
+                {
+                    "name": "a003_LOCAL_SETUP",
+                    "section": "LOCAL_SETUP",
+                    "status": "READY",
+                    "member": None,
+                    "chunk": None,
+                    "platform": "LOCAL",
+                    "chunk_size": 4,
+                    "chunk_unit": "month",
+                    "processors": 1,
+                    "last_wrapper": None,
+                },
+            ),
+            (
+                "a6zj",
+                "a6zj_LOCAL_SETUP",
+                {
+                    "name": "a6zj_LOCAL_SETUP",
+                    "section": "LOCAL_SETUP",
+                    "status": "READY",
+                    "member": None,
+                    "chunk": None,
+                    "platform": "LOCAL",
+                    "chunk_size": 4,
+                    "chunk_unit": "month",
+                    "processors": 1,
+                    "last_wrapper": None,
+                },
+            ),
+            (
+                "a6zj",
+                "a6zj_20000101_fc0_1_SIM",
+                {
+                    "name": "a6zj_20000101_fc0_1_SIM",
+                    "section": "SIM",
+                    "status": "WAITING",
+                    "member": "fc0",
+                    "chunk": 1,
+                    "date": "20000101",
+                    "platform": "MARENOSTRUM4",
+                    "wallclock": "00:05",
+                    "chunk_size": 4,
+                    "chunk_unit": "month",
+                    "processors": 1,
+                    "last_wrapper": "a6zj_ASThread_17128472368642_1_4",
+                },
+            ),
+            (
+                "a6zj",
+                "a6zj_20000101_fc0_INI",
+                {
+                    "name": "a6zj_20000101_fc0_INI",
+                    "section": "INI",
+                    "status": "WAITING",
+                    "member": "fc0",
+                    "chunk": None,
+                    "date": "20000101",
+                    "platform": "MARENOSTRUM4",
+                    "wallclock": "00:05",
+                    "chunk_size": 4,
+                    "chunk_unit": "month",
+                    "processors": 1,
+                    "last_wrapper": None,
+                },
+            ),
+            (
+                "a3tb",
+                "a3tb_19930101_fc01_1_SIM",
+                {
+                    "name": "a3tb_19930101_fc01_1_SIM",
+                    "section": "SIM",
+                    "status": "COMPLETED",
+                    "member": "fc01",
+                    "chunk": 1,
+                    "date": "19930101",
+                    "remote_id": 21131708,
+                    "qos": "debug",
+                    "processors": 768,
+                    "wallclock": "1:30",
+                    "last_wrapper": None,
+                },
+            ),
+        ],
+    )
+    def test_job_detail_fields(
+        self,
+        fixture_fastapi_client: TestClient,
+        expid: str,
+        job_name: str,
+        expected: dict,
+    ):
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name)
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        for key, value in expected.items():
+            assert key in resp_obj
+            assert resp_obj[key] == value
+
+
+class TestExperimentJobParents:
+    endpoint = "/v4/experiments/{expid}/jobs/{job_name}/parents"
+
+    def test_job_not_found(self, fixture_fastapi_client: TestClient):
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid="a003", job_name="a003_NONEXISTENT_JOB")
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert resp_obj["parents"] == []
+
+    def test_no_parents(self, fixture_fastapi_client: TestClient):
+        # LOCAL_SETUP is the root — it has no parents
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid="a003", job_name="a003_LOCAL_SETUP")
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert isinstance(resp_obj["parents"], list)
+        assert len(resp_obj["parents"]) == 0
+
+    @pytest.mark.parametrize(
+        "expid, job_name, expected_parents",
+        [
+            ("a003", "a003_REMOTE_SETUP", ["a003_LOCAL_SETUP"]),
+            ("a003", "a003_20220401_fc0_INI", ["a003_REMOTE_SETUP"]),
+            ("a003", "a003_20220401_fc0_1_SIM", ["a003_20220401_fc0_INI"]),
+            ("a6zj", "a6zj_REMOTE_SETUP", ["a6zj_LOCAL_SETUP"]),
+            ("a6zj", "a6zj_20000101_fc0_INI", ["a6zj_REMOTE_SETUP"]),
+            ("a6zj", "a6zj_20000101_fc0_1_SIM", ["a6zj_20000101_fc0_INI"]),
+        ],
+    )
+    def test_parents(
+        self,
+        fixture_fastapi_client: TestClient,
+        expid: str,
+        job_name: str,
+        expected_parents: list,
+    ):
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name)
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert isinstance(resp_obj["parents"], list)
+        assert len(resp_obj["parents"]) == len(expected_parents)
+        parent_names = [p["job_name"] for p in resp_obj["parents"]]
+        assert sorted(parent_names) == sorted(expected_parents)
+        for parent in resp_obj["parents"]:
+            assert "status" not in parent
+
+    def test_parents_with_status(self, fixture_fastapi_client: TestClient):
+        expid = "a003"
+        job_name = "a003_REMOTE_SETUP"
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name),
+            params={"include_status": True},
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert len(resp_obj["parents"]) == 1
+        parent = resp_obj["parents"][0]
+        assert parent["job_name"] == "a003_LOCAL_SETUP"
+        assert "status" in parent
+        assert isinstance(parent["status"], str)
+
+
+class TestExperimentJobChildren:
+    endpoint = "/v4/experiments/{expid}/jobs/{job_name}/children"
+
+    def test_job_not_found(self, fixture_fastapi_client: TestClient):
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid="a003", job_name="a003_NONEXISTENT_JOB")
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert resp_obj["children"] == []
+
+    def test_no_children(self, fixture_fastapi_client: TestClient):
+        # TRANSFER is a leaf — it has no children
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid="a003", job_name="a003_20220401_fc0_TRANSFER")
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert isinstance(resp_obj["children"], list)
+        assert len(resp_obj["children"]) == 0
+
+    @pytest.mark.parametrize(
+        "expid, job_name, expected_children",
+        [
+            ("a003", "a003_LOCAL_SETUP", ["a003_REMOTE_SETUP"]),
+            ("a003", "a003_REMOTE_SETUP", ["a003_20220401_fc0_INI"]),
+            ("a003", "a003_20220401_fc0_INI", ["a003_20220401_fc0_1_SIM"]),
+            ("a6zj", "a6zj_LOCAL_SETUP", ["a6zj_REMOTE_SETUP"]),
+            ("a6zj", "a6zj_20000101_fc0_INI", ["a6zj_20000101_fc0_1_SIM"]),
+            ("a6zj", "a6zj_20000101_fc0_1_SIM", ["a6zj_20000101_fc0_2_SIM"]),
+        ],
+    )
+    def test_children(
+        self,
+        fixture_fastapi_client: TestClient,
+        expid: str,
+        job_name: str,
+        expected_children: list,
+    ):
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name)
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert isinstance(resp_obj["children"], list)
+        assert len(resp_obj["children"]) == len(expected_children)
+        child_names = [c["job_name"] for c in resp_obj["children"]]
+        assert sorted(child_names) == sorted(expected_children)
+        for child in resp_obj["children"]:
+            assert "status" not in child
+
+    def test_children_with_status(self, fixture_fastapi_client: TestClient):
+        expid = "a003"
+        job_name = "a003_LOCAL_SETUP"
+        response = fixture_fastapi_client.get(
+            self.endpoint.format(expid=expid, job_name=job_name),
+            params={"include_status": True},
+        )
+        resp_obj: dict = response.json()
+
+        assert response.status_code == HTTPStatus.OK
+        assert len(resp_obj["children"]) == 1
+        child = resp_obj["children"][0]
+        assert child["job_name"] == "a003_REMOTE_SETUP"
+        assert "status" in child
+        assert isinstance(child["status"], str)
 
 
 class TestExperimentWrappers:


### PR DESCRIPTION
Related to https://github.com/BSC-ES/autosubmit-gui/issues/215, and possible to do it efficiently with the changes of Autosubmit 4.2.0.

This PR will allow get the details of an individual job, instead of loading all the jobs at once. For the first phase, it will try to get all the essential data as fast as possible. In order to follow that, some things might not be included, like the wrappers details, children, parents, and fixed queue times due to wrappers (SubManager process).

The main use of this endpoint(s) is to retrieve data for the Quick View, which now can have a similar panel as the Tree/Graph View. When the redesign of the Tree/Graph view is ongoing, this endpoint is expected to be used as well.

Introduced endpoint(s):

- GET `v4/experiments/{expid}/jobs/{job_name}`
- GET `v4/experiments/{expid}/jobs/{job_name}/children`
- GET `v4/experiments/{expid}/jobs/{job_name}/parents`
- ~GET `v4/experiments/{expid}/jobs/{job_name}/wrappers`~