### PR TITLE
Add update of the status before stopping the experiment

### DIFF
--- a/autosubmit_api/runners/local_runner.py
+++ b/autosubmit_api/runners/local_runner.py
@@ -186,6 +186,8 @@ class LocalRunner(Runner):
 
         :param expid: The experiment ID to stop.
         """
+        # Force update of the runner status in case the process is not running anymore but the status is still active in the DB.
+        self.get_runner_status(expid)
         # Get the process from the DB
         active_procs = self.runners_repo.get_active_processes_by_expid(expid)
         if not active_procs:

--- a/autosubmit_api/runners/ssh_runner.py
+++ b/autosubmit_api/runners/ssh_runner.py
@@ -341,6 +341,8 @@ class SSHRunner(Runner):
         """
         Stop the remote Autosubmit experiment by killing the process.
         """
+        # Force update of the runner status in case the process is not running anymore but the status is still active in the DB.
+        self.get_runner_status(expid)
         # Get the process from the DB
         active_procs = self.runners_repo.get_active_processes_by_expid(expid)
         if not active_procs:


### PR DESCRIPTION
Add a check to force the update of the status of the runner before stopping, to help GUI users update the status and not deadlock it.