### PR TITLE
Refactor experiment status traceability

### DIFF
--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -48,7 +48,7 @@ class StatusUpdater(BackgroundTaskTemplate):
         cls, experiment_statuses: Optional[List[ExperimentStatusModel]] = None
     ) -> Dict[str, ExperimentStatusModel]:
         """
-        Return only mutable experiment statuses.
+        Return only mutable experiment statuses: RUNNING and empty status experiments.
         """
         if experiment_statuses is None:
             status_repository = create_experiment_status_repository()
@@ -74,7 +74,7 @@ class StatusUpdater(BackgroundTaskTemplate):
         Decide if the experiment is running using last_heartbeat as the main signal.
 
         Priority order:
-        1. Check as_times.db last_heartbeat column (most reliable, updated by backend every 2 min)
+        1. Check database last_heartbeat column (most reliable, updated by backend every 2 min)
         2. Check pickle file age (secondary, faster than filesystem exhaustive check)
         3. Check run.log file (last resort, most exhaustive and slow)
         """
@@ -87,7 +87,7 @@ class StatusUpdater(BackgroundTaskTemplate):
 
         try:
             current_time = int(time.time())
-            # Priority 1: Check last_heartbeat timestamp from as_times.db
+            # Priority 1: Check last_heartbeat timestamp from db
             if status_row and status_row.last_heartbeat:
                 try:
                     from datetime import datetime as dt

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -191,15 +191,6 @@ class StatusUpdater(BackgroundTaskTemplate):
             )
             return
 
-        # Read experiments table
-        try:
-            exp_list = cls._get_experiments()
-        except Exception as exc:
-            cls.logger.error(
-                f"[{cls.id}] Error loading experiments: {exc}"
-            )
-            return
-
         # Read current status of RUNNING experiments
         try:
             current_status_dict = cls._get_current_status()

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -20,7 +20,7 @@ from autosubmit_api.repositories.join.experiment_join import (
 
 class StatusUpdater(BackgroundTaskTemplate):
     id = "TASK_STTSUPDTR"
-    trigger_options = {"trigger": "interval", "minutes": 1}
+    trigger_options = {"trigger": "interval", "minutes": 5}
 
     @classmethod
     def _clear_missing_experiments(cls):

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -19,8 +19,7 @@ from autosubmit_api.repositories.join.experiment_join import (
 
 class StatusUpdater(BackgroundTaskTemplate):
     id = "TASK_STTSUPDTR"
-    # TODO: the minute timer will need to change to 5. Just for testing
-    trigger_options = {"trigger": "interval", "minutes": 2}
+    trigger_options = {"trigger": "interval", "minutes": 5}
 
     @classmethod
     def _clear_missing_experiments(cls):

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -50,7 +50,24 @@ class StatusUpdater(BackgroundTaskTemplate):
         """
         status_repository = create_experiment_status_repository()
         experiment_statuses = status_repository.get_all()
-        return {row.name: row.status for row in experiment_statuses}
+        # Filter out terminal statuses
+        terminal_statuses = [
+            RunningStatus.ARCHIVED,
+            RunningStatus.DELETED,
+            RunningStatus.NOT_RUNNING,
+        ]
+        mutable_statuses = {
+            row.name: row
+            for row in experiment_statuses
+            if row.status not in terminal_statuses
+        }
+
+        cls.logger.debug(
+            f"[{cls.id}] Loaded {len(mutable_statuses)} mutable experiments "
+            f"(filtered out {len(experiment_statuses) - len(mutable_statuses)} terminal statuses)"
+        )
+
+        return mutable_statuses
 
     @classmethod
     def _check_exp_running(cls, expid: str, status_row: Optional[ExperimentStatusModel] = None) -> bool:
@@ -62,7 +79,6 @@ class StatusUpdater(BackgroundTaskTemplate):
         2. Check pickle file age (secondary, faster than filesystem exhaustive check)
         3. Check run.log file (last resort, most exhaustive and slow)
         """
-        # TODO: define last_heartbeat age threshold
         MAX_HEARTBEAT_AGE = 150 # 2.5 minutes
         MAX_PKL_AGE = 600  # 10 minutes
         MAX_PKL_AGE_EXHAUSTIVE = 3600  # 1 hour
@@ -87,28 +103,28 @@ class StatusUpdater(BackgroundTaskTemplate):
                     cls.logger.warning(
                         f"[{cls.id}] Could not parse heartbeat for {expid}: {exc}"
                     )
+            else:
+                try:
+                    job_list_repo = create_jobs_repository(expid)
+                    pkl_age = current_time - job_list_repo.get_last_modified_timestamp()
 
-            try:
-                job_list_repo = create_jobs_repository(expid)
-                pkl_age = current_time - job_list_repo.get_last_modified_timestamp()
-                
-                # Priority 2: Check pickle file age
-                if pkl_age < MAX_PKL_AGE:  # First running check
-                    is_running = True
-                    return is_running
-                
-                # Priority 3: Exhaustive check using filesystem
-                elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
-                    _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
-                    if _flag:
+                    # Priority 2: Check pickle file age
+                    if pkl_age < MAX_PKL_AGE:  # First running check
                         is_running = True
                         return is_running
-            
-            except Exception as exc:
-                cls.logger.warning(
-                    f"[{cls.id}] Could not check pickle file for {expid}: {exc}"
-                )
-            
+
+                    # Priority 3: Exhaustive check using filesystem
+                    elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
+                        _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
+                        if _flag:
+                            is_running = True
+                            return is_running
+
+                except Exception as exc:
+                    cls.logger.warning(
+                        f"[{cls.id}] Could not check pickle file for {expid}: {exc}"
+                    )
+
             cls.logger.debug(
                 f"[{cls.id}] Experiment {expid} is not running: "
                 f"heartbeat_age={heartbeat_age if status_row and status_row.last_heartbeat else 'N/A'}s, "
@@ -118,11 +134,11 @@ class StatusUpdater(BackgroundTaskTemplate):
             cls.logger.error(
                 f"[{cls.id}] Error while checking if experiment {expid} is running: {exc}"
             )
-        
+
         return is_running
 
     @classmethod
-    def _update_experiment_status(cls, experiment: ExperimentModel, is_running: bool, status_row: Optional[ExperimentStatusModel] = None):
+    def _update_experiment_status(cls, experiment: ExperimentStatusModel, is_running: bool, status_row: Optional[ExperimentStatusModel] = None):
         """
         Update experiment status using guarded conditional update.
 
@@ -137,7 +153,7 @@ class StatusUpdater(BackgroundTaskTemplate):
         try:
             # Use guarded upsert to protect terminal states
             success = status_repository.upsert_status(
-                exp_id=experiment.id,
+                exp_id=experiment.exp_id,
                 expid=experiment.name,
                 status=new_status,
                 last_heartbeat=last_heartbeat,
@@ -194,7 +210,10 @@ class StatusUpdater(BackgroundTaskTemplate):
             return
 
         # Check every experiment status & update (skip terminal statuses)
-        for experiment in exp_list:
+        for experiment in current_status_dict.values():
+            cls.logger.error(
+                f"[{cls.id}] Processing experiment {experiment.name} with current status {experiment.status}"
+            )
             exp_name = experiment.name
             status_row = current_status_dict.get(exp_name)
 
@@ -204,8 +223,7 @@ class StatusUpdater(BackgroundTaskTemplate):
                     cls.logger.info(
                         f"[{cls.id}] Initializing new experiment {exp_name} status"
                     )
-                    # TODO: problems with experiments that do not have status
-                    # How to distinguish between NOT RUNNING, ARCHIVED and DELETED?
+                    # Set missing experiments as NOT RUNNING by default
                     cls._update_experiment_status(experiment, is_running=False, status_row=None)
                 except Exception as exc:
                     cls.logger.error(

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -85,59 +85,54 @@ class StatusUpdater(BackgroundTaskTemplate):
         is_running = False
         check_pickle = True
 
-        try:
-            current_time = int(time.time())
-            # Priority 1: Check last_heartbeat timestamp from db
-            if status_row and status_row.last_heartbeat:
-                try:
-                    from datetime import datetime as dt
-                    heartbeat_dt = dt.fromisoformat(status_row.last_heartbeat)
-                    heartbeat_timestamp = int(heartbeat_dt.timestamp())
-                    heartbeat_age = current_time - heartbeat_timestamp
+        current_time = int(time.time())
+        # Priority 1: Check last_heartbeat timestamp from db
+        if status_row and status_row.last_heartbeat:
+            try:
+                from datetime import datetime as dt
+                heartbeat_dt = dt.fromisoformat(status_row.last_heartbeat)
+                heartbeat_timestamp = int(heartbeat_dt.timestamp())
+                heartbeat_age = current_time - heartbeat_timestamp
 
-                    # Fresh heartbeat signal, experiment is still running
-                    if heartbeat_age < MAX_HEARTBEAT_AGE:
+                # Fresh heartbeat signal, experiment is still running
+                if heartbeat_age < MAX_HEARTBEAT_AGE:
+                    is_running = True
+                    return is_running
+                # Heartbeat is stale, don't fall back to pickle
+                check_pickle = False
+            except Exception as exc:
+                cls.logger.warning(
+                    f"[{cls.id}] Could not parse heartbeat for {expid}: {exc}"
+                )
+                # Unparsable heartbeat, fall back to pickle check
+                check_pickle = True
+        
+        # Priority 2 and 3: Check pickle file if no valid heartbeat
+        if check_pickle:
+            try:
+                job_list_repo = create_jobs_repository(expid)
+                pkl_age = current_time - job_list_repo.get_last_modified_timestamp()
+
+                # Priority 2: Check pickle file age
+                if pkl_age < MAX_PKL_AGE:  # First running check
+                    is_running = True
+                    return is_running
+
+                # Priority 3: Check using filesystem
+                elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
+                    _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
+                    if _flag:
                         is_running = True
                         return is_running
-                    # Heartbeat is stale, don't fall back to pickle
-                    check_pickle = False
-                except Exception as exc:
-                    cls.logger.warning(
-                        f"[{cls.id}] Could not parse heartbeat for {expid}: {exc}"
-                    )
-                    # Unparsable heartbeat, fall back to pickle check
-                    check_pickle = True
-            
-            # Priority 2 and 3: Check pickle file if no valid heartbeat
-            if check_pickle:
-                try:
-                    job_list_repo = create_jobs_repository(expid)
-                    pkl_age = current_time - job_list_repo.get_last_modified_timestamp()
 
-                    # Priority 2: Check pickle file age
-                    if pkl_age < MAX_PKL_AGE:  # First running check
-                        is_running = True
-                        return is_running
+            except Exception as exc:
+                cls.logger.warning(
+                    f"[{cls.id}] Could not check pickle file for {expid}: {exc}"
+                )
 
-                    # Priority 3: Check using filesystem
-                    elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
-                        _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
-                        if _flag:
-                            is_running = True
-                            return is_running
-
-                except Exception as exc:
-                    cls.logger.warning(
-                        f"[{cls.id}] Could not check pickle file for {expid}: {exc}"
-                    )
-
-            cls.logger.debug(
-                f"[{cls.id}] Experiment {expid} is not running"
-            )
-        except Exception as exc:
-            cls.logger.error(
-                f"[{cls.id}] Error while checking if experiment {expid} is running: {exc}"
-            )
+        cls.logger.debug(
+            f"[{cls.id}] Experiment {expid} is not running"
+        )
 
         return is_running
 

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from autosubmit_api.bgtasks.bgtask import BackgroundTaskTemplate
 from autosubmit_api.experiment.common_requests import _is_exp_running
@@ -9,6 +9,7 @@ from autosubmit_api.repositories.experiment import (
     create_experiment_repository,
 )
 from autosubmit_api.repositories.experiment_status import (
+    ExperimentStatusModel,
     create_experiment_status_repository,
 )
 from autosubmit_api.repositories.jobs import create_jobs_repository
@@ -19,7 +20,7 @@ from autosubmit_api.repositories.join.experiment_join import (
 
 class StatusUpdater(BackgroundTaskTemplate):
     id = "TASK_STTSUPDTR"
-    trigger_options = {"trigger": "interval", "minutes": 5}
+    trigger_options = {"trigger": "interval", "minutes": 1}
 
     @classmethod
     def _clear_missing_experiments(cls):
@@ -43,91 +44,188 @@ class StatusUpdater(BackgroundTaskTemplate):
         return experiment_repository.get_all()
 
     @classmethod
-    def _get_current_status(cls) -> Dict[str, str]:
+    def _get_current_status(cls) -> Dict[str, ExperimentStatusModel]:
         """
-        Get the current status of the experiments filtering out ARCHIVED/DELETED/NOT RUNNING ones.
+        Get the current status of the experiments.
         """
         status_repository = create_experiment_status_repository()
         experiment_statuses = status_repository.get_all()
-
-        # Filter out terminal statuses: only reconcile RUNNING experiments
-        terminal_statuses = {
-            RunningStatus.NOT_RUNNING,
-            RunningStatus.ARCHIVED,
-            RunningStatus.DELETED,
-        }
-        mutable_statuses = {
-            row.name: row
-            for row in experiment_statuses
-            if row.status not in terminal_statuses
-        }
-        cls.logger.debug(
-            f"[{cls.id}] Loaded {len(mutable_statuses)} mutable experiments "
-            f"(filtered {len(experiment_statuses) - len(mutable_statuses)} terminal statuses)"
-        )
-        return mutable_statuses
+        return {row.name: row.status for row in experiment_statuses}
 
     @classmethod
-    def _check_exp_running(cls, expid: str) -> bool:
+    def _check_exp_running(cls, expid: str, status_row: Optional[ExperimentStatusModel] = None) -> bool:
         """
-        Decide if the experiment is running
+        Decide if the experiment is running using last_heartbeat as the main signal.
+
+        Priority order:
+        1. Check as_times.db last_heartbeat column (most reliable, updated by backend every 2 min)
+        2. Check pickle file age (secondary, faster than filesystem exhaustive check)
+        3. Check run.log file (last resort, most exhaustive and slow)
         """
+        # TODO: define last_heartbeat age threshold
+        MAX_HEARTBEAT_AGE = 150 # 2.5 minutes
         MAX_PKL_AGE = 600  # 10 minutes
         MAX_PKL_AGE_EXHAUSTIVE = 3600  # 1 hour
 
         is_running = False
-        try:
-            job_list_repo = create_jobs_repository(expid)
-            pkl_age = int(time.time()) - job_list_repo.get_last_modified_timestamp()
 
-            if pkl_age < MAX_PKL_AGE:  # First running check
-                is_running = True
-            elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
-                _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
-                if _flag:
+        try:
+            current_time = int(time.time())
+            # Priority 1: Check last_heartbeat timestamp from as_times.db
+            if status_row and status_row.last_heartbeat:
+                try:
+                    from datetime import datetime as dt
+                    heartbeat_dt = dt.fromisoformat(status_row.last_heartbeat)
+                    heartbeat_timestamp = int(heartbeat_dt.timestamp())
+                    heartbeat_age = current_time - heartbeat_timestamp
+
+                    # Fresh heartbeat signal, experiment is still running
+                    if heartbeat_age < MAX_HEARTBEAT_AGE:
+                        is_running = True
+                        return is_running
+                except Exception as exc:
+                    cls.logger.warning(
+                        f"[{cls.id}] Could not parse heartbeat for {expid}: {exc}"
+                    )
+
+            try:
+                job_list_repo = create_jobs_repository(expid)
+                pkl_age = current_time - job_list_repo.get_last_modified_timestamp()
+                
+                # Priority 2: Check pickle file age
+                if pkl_age < MAX_PKL_AGE:  # First running check
                     is_running = True
+                    return is_running
+                
+                # Priority 3: Exhaustive check using filesystem
+                elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
+                    _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
+                    if _flag:
+                        is_running = True
+                        return is_running
+            
+            except Exception as exc:
+                cls.logger.warning(
+                    f"[{cls.id}] Could not check pickle file for {expid}: {exc}"
+                )
+            
+            cls.logger.debug(
+                f"[{cls.id}] Experiment {expid} is not running: "
+                f"heartbeat_age={heartbeat_age if status_row and status_row.last_heartbeat else 'N/A'}s, "
+                f"pkl_age={pkl_age if 'pkl_age' in locals() else 'N/A'}s"
+            )
         except Exception as exc:
             cls.logger.error(
-                f"[{cls.id}] Error while checking experiment {expid}: {exc}"
+                f"[{cls.id}] Error while checking if experiment {expid} is running: {exc}"
             )
-
+        
         return is_running
 
     @classmethod
-    def _update_experiment_status(cls, experiment: ExperimentModel, is_running: bool):
+    def _update_experiment_status(cls, experiment: ExperimentModel, is_running: bool, status_row: Optional[ExperimentStatusModel] = None):
+        """
+        Update experiment status using guarded conditional update.
+
+        Guard against overwritting ARCHIVED/DELETED/NOT RUNNING status.
+        """
         status_repository = create_experiment_status_repository()
+        new_status = RunningStatus.RUNNING if is_running else RunningStatus.NOT_RUNNING
+
+        # Get the last_heartbeat if available (old experiments might not have it)
+        last_heartbeat = status_row.last_heartbeat if status_row else None
+
         try:
-            status_repository.upsert_status(
-                experiment.id,
-                experiment.name,
-                RunningStatus.RUNNING if is_running else RunningStatus.NOT_RUNNING,
+            # Use guarded upsert to protect terminal states
+            success = status_repository.upsert_status(
+                exp_id=experiment.id,
+                expid=experiment.name,
+                status=new_status,
+                last_heartbeat=last_heartbeat,
             )
+
+            if not success:
+                # Update was rejected: log warning
+                current_status = status_row.status if status_row else "UNKNOWN"
+                cls.logger.warning(
+                    f"[{cls.id}] Status update rejected for experiment {experiment.name}: "
+                    f"attempted to update {new_status} on old state {current_status}"
+                )
+            else:
+                cls.logger.info(
+                    f"[{cls.id}] Status updated for experiment {experiment.name} to {new_status}"
+                )
         except Exception as exc:
             cls.logger.error(
-                f"[{cls.id}] Error while doing database operations on experiment {experiment.name}: {exc}"
+                f"[{cls.id}] Error while updating status for experiment {experiment.name}: {exc}"
             )
 
     @classmethod
     def procedure(cls):
         """
-        Updates STATUS of experiments.
+        Updates STATUS of RUNNING experiments (RUNNING -> NOT RUNNING).
+
+        Skipts ARCHIVED, DELETED and NOT RUNNING experiments.
+        Uses last_heartbeat as the main signal for RUNNING detection.
         """
-        cls._clear_missing_experiments()
+        try:
+            cls._clear_missing_experiments()
+        except Exception as exc:
+            cls.logger.error(
+                f"[{cls.id}] Error while clearing missing experiments: {exc}"
+            )
+            return
 
         # Read experiments table
-        exp_list = cls._get_experiments()
+        try:
+            exp_list = cls._get_experiments()
+        except Exception as exc:
+            cls.logger.error(
+                f"[{cls.id}] Error loading experiments: {exc}"
+            )
+            return
 
-        # Read current status of all experiments
-        current_status = cls._get_current_status()
+        # Read current status of RUNNING experiments
+        try:
+            current_status_dict = cls._get_current_status()
+        except Exception as exc:
+            cls.logger.error(
+                f"[{cls.id}] Error loading current experiment statuses: {exc}"
+            )
+            return
 
-        # Check every experiment status & update
+        # Check every experiment status & update (skip terminal statuses)
         for experiment in exp_list:
-            is_running = cls._check_exp_running(experiment.name)
+            exp_name = experiment.name
+            status_row = current_status_dict.get(exp_name)
+
+            if status_row is None:
+                # New experiment or no status yet: create with NOT RUNNING for retro-compatibility
+                try:
+                    cls.logger.info(
+                        f"[{cls.id}] Initializing new experiment {exp_name} status"
+                    )
+                    # TODO: problems with experiments that do not have status
+                    # How to distinguish between NOT RUNNING, ARCHIVED and DELETED?
+                    cls._update_experiment_status(experiment, is_running=False, status_row=None)
+                except Exception as exc:
+                    cls.logger.error(
+                        f"[{cls.id}] Error initializing status for experiment {exp_name}: {exc}"
+                    )
+                continue
+
+            # Check if experiment is running
+            is_running = cls._check_exp_running(exp_name, status_row)
             new_status = (
                 RunningStatus.RUNNING if is_running else RunningStatus.NOT_RUNNING
             )
-            if current_status.get(experiment.name) != new_status:
+
+            # Only update if status changed
+            if status_row.status != new_status:
                 cls.logger.info(
                     f"[{cls.id}] Updating status of {experiment.name} to {new_status}"
                 )
-                cls._update_experiment_status(experiment, is_running)
+                cls._update_experiment_status(experiment, is_running, status_row)
+
+            cls.logger.info(
+                f"[{cls.id}] Status updater completed"
+            )

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -83,6 +83,7 @@ class StatusUpdater(BackgroundTaskTemplate):
         MAX_PKL_AGE_EXHAUSTIVE = 3600  # 1 hour
 
         is_running = False
+        check_pickle = True
 
         try:
             current_time = int(time.time())
@@ -98,11 +99,17 @@ class StatusUpdater(BackgroundTaskTemplate):
                     if heartbeat_age < MAX_HEARTBEAT_AGE:
                         is_running = True
                         return is_running
+                    # Heartbeat is stale, don't fall back to pickle
+                    check_pickle = False
                 except Exception as exc:
                     cls.logger.warning(
                         f"[{cls.id}] Could not parse heartbeat for {expid}: {exc}"
                     )
-            else:
+                    # Unparsable heartbeat, fall back to pickle check
+                    check_pickle = True
+            
+            # Priority 2 and 3: Check pickle file if no valid heartbeat
+            if check_pickle:
                 try:
                     job_list_repo = create_jobs_repository(expid)
                     pkl_age = current_time - job_list_repo.get_last_modified_timestamp()
@@ -125,9 +132,7 @@ class StatusUpdater(BackgroundTaskTemplate):
                     )
 
             cls.logger.debug(
-                f"[{cls.id}] Experiment {expid} is not running: "
-                f"heartbeat_age={heartbeat_age if status_row and status_row.last_heartbeat else 'N/A'}s, "
-                f"pkl_age={pkl_age if 'pkl_age' in locals() else 'N/A'}s"
+                f"[{cls.id}] Experiment {expid} is not running"
             )
         except Exception as exc:
             cls.logger.error(

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -44,12 +44,16 @@ class StatusUpdater(BackgroundTaskTemplate):
         return experiment_repository.get_all()
 
     @classmethod
-    def _get_current_status(cls) -> Dict[str, ExperimentStatusModel]:
+    def _get_mutable_statuses(
+        cls, experiment_statuses: Optional[List[ExperimentStatusModel]] = None
+    ) -> Dict[str, ExperimentStatusModel]:
         """
-        Get the current status of the experiments.
+        Return only mutable experiment statuses.
         """
-        status_repository = create_experiment_status_repository()
-        experiment_statuses = status_repository.get_all()
+        if experiment_statuses is None:
+            status_repository = create_experiment_status_repository()
+            experiment_statuses = status_repository.get_all()
+
         # Filter out terminal statuses
         terminal_statuses = [
             RunningStatus.ARCHIVED,
@@ -61,11 +65,6 @@ class StatusUpdater(BackgroundTaskTemplate):
             for row in experiment_statuses
             if row.status not in terminal_statuses
         }
-
-        cls.logger.debug(
-            f"[{cls.id}] Loaded {len(mutable_statuses)} mutable experiments "
-            f"(filtered out {len(experiment_statuses) - len(mutable_statuses)} terminal statuses)"
-        )
 
         return mutable_statuses
 
@@ -113,7 +112,7 @@ class StatusUpdater(BackgroundTaskTemplate):
                         is_running = True
                         return is_running
 
-                    # Priority 3: Exhaustive check using filesystem
+                    # Priority 3: Check using filesystem
                     elif pkl_age < MAX_PKL_AGE_EXHAUSTIVE:  # Exhaustive check
                         _, _, _flag, _, _ = _is_exp_running(expid)  # Exhaustive validation
                         if _flag:
@@ -138,7 +137,12 @@ class StatusUpdater(BackgroundTaskTemplate):
         return is_running
 
     @classmethod
-    def _update_experiment_status(cls, experiment: ExperimentStatusModel, is_running: bool, status_row: Optional[ExperimentStatusModel] = None):
+    def _update_experiment_status(
+        cls,
+        experiment: ExperimentModel,
+        is_running: bool,
+        status_row: Optional[ExperimentStatusModel] = None,
+    ):
         """
         Update experiment status using guarded conditional update.
 
@@ -151,9 +155,8 @@ class StatusUpdater(BackgroundTaskTemplate):
         last_heartbeat = status_row.last_heartbeat if status_row else None
 
         try:
-            # Use guarded upsert to protect terminal states
             success = status_repository.upsert_status(
-                exp_id=experiment.exp_id,
+                exp_id=experiment.id,
                 expid=experiment.name,
                 status=new_status,
                 last_heartbeat=last_heartbeat,
@@ -180,7 +183,8 @@ class StatusUpdater(BackgroundTaskTemplate):
         """
         Updates STATUS of RUNNING experiments (RUNNING -> NOT RUNNING).
 
-        Skipts ARCHIVED, DELETED and NOT RUNNING experiments.
+        Skips ARCHIVED, DELETED and NOT_RUNNING experiments (terminal statuses).
+        Checks RUNNING status and empty status experiments.
         Uses last_heartbeat as the main signal for RUNNING detection.
         """
         try:
@@ -191,38 +195,51 @@ class StatusUpdater(BackgroundTaskTemplate):
             )
             return
 
-        # Read current status of RUNNING experiments
+        status_repository = create_experiment_status_repository()
+
+        # Read current status snapshots once.
         try:
-            current_status_dict = cls._get_current_status()
+            all_status_rows = status_repository.get_all()
         except Exception as exc:
             cls.logger.error(
                 f"[{cls.id}] Error loading current experiment statuses: {exc}"
             )
             return
 
-        # Check every experiment status & update (skip terminal statuses)
-        for experiment in current_status_dict.values():
-            cls.logger.error(
-                f"[{cls.id}] Processing experiment {experiment.name} with current status {experiment.status}"
-            )
-            exp_name = experiment.name
-            status_row = current_status_dict.get(exp_name)
+        all_status_dict = {row.name: row for row in all_status_rows}
+        current_status_dict = cls._get_mutable_statuses(all_status_rows)
+        all_experiments = {
+            experiment.name: experiment for experiment in cls._get_experiments()
+        }
 
-            if status_row is None:
-                # New experiment or no status yet: create with NOT RUNNING for retro-compatibility
-                try:
-                    cls.logger.info(
-                        f"[{cls.id}] Initializing new experiment {exp_name} status"
-                    )
-                    # Set missing experiments as NOT RUNNING by default
-                    cls._update_experiment_status(experiment, is_running=False, status_row=None)
-                except Exception as exc:
-                    cls.logger.error(
-                        f"[{cls.id}] Error initializing status for experiment {exp_name}: {exc}"
-                    )
+        # Initialize experiments that are not yet present in the status table.
+        for exp_name, experiment in all_experiments.items():
+            if exp_name in all_status_dict:
                 continue
 
-            # Check if experiment is running
+            try:
+                cls.logger.debug(
+                    f"[{cls.id}] Initializing new experiment {exp_name} status"
+                )
+                cls._update_experiment_status(
+                    experiment,
+                    is_running=False,
+                    status_row=None,
+                )
+            except Exception as exc:
+                cls.logger.error(
+                    f"[{cls.id}] Error initializing status for experiment {exp_name}: {exc}"
+                )
+
+        # Evaluate only mutable experiments (RUNNING and empty status)
+        for exp_name, status_row in current_status_dict.items():
+            experiment = all_experiments.get(exp_name)
+            if experiment is None:
+                cls.logger.warning(
+                    f"[{cls.id}] Experiment {exp_name} found in status table but not in experiments table"
+                )
+                continue
+
             is_running = cls._check_exp_running(exp_name, status_row)
             new_status = (
                 RunningStatus.RUNNING if is_running else RunningStatus.NOT_RUNNING
@@ -230,11 +247,9 @@ class StatusUpdater(BackgroundTaskTemplate):
 
             # Only update if status changed
             if status_row.status != new_status:
-                cls.logger.info(
+                cls.logger.debug(
                     f"[{cls.id}] Updating status of {experiment.name} to {new_status}"
                 )
                 cls._update_experiment_status(experiment, is_running, status_row)
 
-            cls.logger.info(
-                f"[{cls.id}] Status updater completed"
-            )
+        cls.logger.debug(f"[{cls.id}] Status updater completed")

--- a/autosubmit_api/bgtasks/tasks/status_updater.py
+++ b/autosubmit_api/bgtasks/tasks/status_updater.py
@@ -19,7 +19,8 @@ from autosubmit_api.repositories.join.experiment_join import (
 
 class StatusUpdater(BackgroundTaskTemplate):
     id = "TASK_STTSUPDTR"
-    trigger_options = {"trigger": "interval", "minutes": 5}
+    # TODO: the minute timer will need to change to 5. Just for testing
+    trigger_options = {"trigger": "interval", "minutes": 2}
 
     @classmethod
     def _clear_missing_experiments(cls):
@@ -45,11 +46,27 @@ class StatusUpdater(BackgroundTaskTemplate):
     @classmethod
     def _get_current_status(cls) -> Dict[str, str]:
         """
-        Get the current status of the experiments
+        Get the current status of the experiments filtering out ARCHIVED/DELETED/NOT RUNNING ones.
         """
         status_repository = create_experiment_status_repository()
         experiment_statuses = status_repository.get_all()
-        return {row.name: row.status for row in experiment_statuses}
+
+        # Filter out terminal statuses: only reconcile RUNNING experiments
+        terminal_statuses = {
+            RunningStatus.NOT_RUNNING,
+            RunningStatus.ARCHIVED,
+            RunningStatus.DELETED,
+        }
+        mutable_statuses = {
+            row.name: row
+            for row in experiment_statuses
+            if row.status not in terminal_statuses
+        }
+        cls.logger.debug(
+            f"[{cls.id}] Loaded {len(mutable_statuses)} mutable experiments "
+            f"(filtered {len(experiment_statuses) - len(mutable_statuses)} terminal statuses)"
+        )
+        return mutable_statuses
 
     @classmethod
     def _check_exp_running(cls, expid: str) -> bool:

--- a/autosubmit_api/database/tables.py
+++ b/autosubmit_api/database/tables.py
@@ -114,7 +114,7 @@ ExperimentStatusTable = Table(
     Column("modified", Text, nullable=False),
 )
 
-# Copy ExperimentStatusTable to an alternative version which has an additional column
+# Copy ExperimentStatusTable to an alternative version which has last_heartbeat column
 ExperimentStatusTableV18 = table_copy(ExperimentStatusTable)
 ExperimentStatusTableV18.append_column(Column("last_heartbeat", Text, nullable=True))
 

--- a/autosubmit_api/database/tables.py
+++ b/autosubmit_api/database/tables.py
@@ -112,8 +112,12 @@ ExperimentStatusTable = Table(
     Column("status", Text, nullable=False),
     Column("seconds_diff", Integer, nullable=False),
     Column("modified", Text, nullable=False),
-    Column("last_heartbeat", Text, nullable=True),
 )
+
+# Copy ExperimentStatusTable to an alternative version which has an additional column
+ExperimentStatusTableV18 = table_copy(ExperimentStatusTable)
+ExperimentStatusTableV18.append_column(Column("last_heartbeat", Text, nullable=True))
+
 """Stores the status of the experiments."""
 
 ExperimentStructureTable = Table(

--- a/autosubmit_api/database/tables.py
+++ b/autosubmit_api/database/tables.py
@@ -112,6 +112,7 @@ ExperimentStatusTable = Table(
     Column("status", Text, nullable=False),
     Column("seconds_diff", Integer, nullable=False),
     Column("modified", Text, nullable=False),
+    Column("last_heartbeat", Text, nullable=True),
 )
 """Stores the status of the experiments."""
 

--- a/autosubmit_api/experiment/common_requests.py
+++ b/autosubmit_api/experiment/common_requests.py
@@ -296,7 +296,7 @@ def _is_exp_running(expid: str, time_condition=300) -> Tuple[bool, str, bool, in
     """
     Tests if experiment is running
     :param expid: Experiment name
-    :param time_condition: Time constraint, 120 by default. Represents max seconds before an experiment is considered as NOT RUNNING
+    :param time_condition: Time constraint, 300 by default. Represents max seconds before an experiment is considered as NOT RUNNING
     :return: (error (true if error is found, false otherwise), error_message, is_running (true if running, false otherwise), timediff, path_to_log)
     """
     patterns = ["_run.log", "_run.log.xz", "_run.log.gz"]

--- a/autosubmit_api/history/database_managers/database_models.py
+++ b/autosubmit_api/history/database_managers/database_models.py
@@ -79,6 +79,8 @@ MaxCounterRow = collections.namedtuple('MaxCounter', ['maxcounter'])
 class RunningStatus:
   RUNNING = "RUNNING"
   NOT_RUNNING = "NOT RUNNING"
+  ARCHIVED = "ARCHIVED"
+  DELETED = "DELETED"
 
 class RowType:
     NORMAL = 2

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -100,7 +100,6 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
         with self.engine.connect() as conn:
             with conn.begin():
                 try:
-                    # TODO: optimize with a single update
                     del_stmnt = delete(self.table).where(self.table.c.exp_id == exp_id)
                     ins_values = dict(
                         exp_id=exp_id,

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -58,9 +58,13 @@ class ExperimentStatusRepository(ABC):
 
 
 class ExperimentStatusSQLRepository(ExperimentStatusRepository):
-    def __init__(self, engine: Engine, table: Table):
+    def __init__(self, engine: Engine, valid_tables: List[Table]):
         self.engine = engine
-        self.table = table
+        self.table = tables.check_table_schema(self.engine, valid_tables)
+        if self.table is None:
+            if len(valid_tables) == 0:
+                raise ValueError("No valid tables provided.")
+            self.table = valid_tables[0]
 
         with self.engine.connect() as conn:
             conn.execute(CreateTable(self.table, if_not_exists=True))
@@ -132,8 +136,12 @@ def create_experiment_status_repository() -> ExperimentStatusRepository:
     if APIBasicConfig.DATABASE_BACKEND == "postgres":
         # PostgreSQL
         _engine = create_engine(APIBasicConfig.DATABASE_CONN_URL)
+        _tables = [
+            tables.table_change_schema(tables.ExperimentStatusTableV18),
+            tables.table_change_schema(tables.ExperimentStatusTable),
+        ]
     else:
         # SQLite
         _engine = create_as_times_db_engine()
-    _table = tables.ExperimentStatusTable
-    return ExperimentStatusSQLRepository(_engine, _table)
+        _tables = [tables.ExperimentStatusTableV18, tables.ExperimentStatusTable]
+    return ExperimentStatusSQLRepository(_engine, _tables)

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -91,7 +91,7 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
             status=result.status,
             seconds_diff=result.seconds_diff,
             modified=result.modified,
-            last_heartbeat=result.last_heartbeat,
+            last_heartbeat=getattr(result, "last_heartbeat", None),
         )
 
     def upsert_status(self, exp_id: int, expid: str, status: str, last_heartbeat: str = None) -> int:
@@ -100,7 +100,7 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
                 try:
                     # TODO: optimize with a single update
                     del_stmnt = delete(self.table).where(self.table.c.exp_id == exp_id)
-                    ins_stmnt = insert(self.table).values(
+                    ins_values = dict(
                         exp_id=exp_id,
                         name=expid,
                         status=status,
@@ -108,8 +108,11 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
                         modified=datetime.now(tz=LOCAL_TZ).isoformat(
                             sep="-", timespec="seconds"
                         ),
-                        last_heartbeat=last_heartbeat,
                     )
+                    if "last_heartbeat" in self.table.c:
+                        ins_values["last_heartbeat"] = last_heartbeat
+
+                    ins_stmnt = insert(self.table).values(**ins_values)
                     conn.execute(del_stmnt)
                     result = conn.execute(ins_stmnt)
                     conn.commit()
@@ -137,8 +140,8 @@ def create_experiment_status_repository() -> ExperimentStatusRepository:
         # PostgreSQL
         _engine = create_engine(APIBasicConfig.DATABASE_CONN_URL)
         _tables = [
-            tables.table_change_schema(source=tables.ExperimentStatusTableV18),
-            tables.table_change_schema(source=tables.ExperimentStatusTable),
+            tables.table_change_schema("as_times", tables.ExperimentStatusTableV18),
+            tables.table_change_schema("as_times", tables.ExperimentStatusTable),
         ]
     else:
         # SQLite

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -18,6 +18,7 @@ class ExperimentStatusModel(BaseModel):
     status: str
     seconds_diff: Any
     modified: Any
+    last_heartbeat: Any = None
 
 
 class ExperimentStatusRepository(ABC):
@@ -38,7 +39,7 @@ class ExperimentStatusRepository(ABC):
         """
 
     @abstractmethod
-    def upsert_status(self, exp_id: int, expid: str, status: str) -> int:
+    def upsert_status(self, exp_id: int, expid: str, status: str, last_heartbeat: str = None) -> int:
         """
         Delete and insert experiment status by expid
         """
@@ -86,12 +87,14 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
             status=result.status,
             seconds_diff=result.seconds_diff,
             modified=result.modified,
+            last_heartbeat=result.last_heartbeat,
         )
 
-    def upsert_status(self, exp_id: int, expid: str, status: str):
+    def upsert_status(self, exp_id: int, expid: str, status: str, last_heartbeat: str = None) -> int:
         with self.engine.connect() as conn:
             with conn.begin():
                 try:
+                    # TODO: optimize with a single update
                     del_stmnt = delete(self.table).where(self.table.c.exp_id == exp_id)
                     ins_stmnt = insert(self.table).values(
                         exp_id=exp_id,
@@ -101,6 +104,7 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
                         modified=datetime.now(tz=LOCAL_TZ).isoformat(
                             sep="-", timespec="seconds"
                         ),
+                        last_heartbeat=last_heartbeat,
                     )
                     conn.execute(del_stmnt)
                     result = conn.execute(ins_stmnt)

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -137,8 +137,8 @@ def create_experiment_status_repository() -> ExperimentStatusRepository:
         # PostgreSQL
         _engine = create_engine(APIBasicConfig.DATABASE_CONN_URL)
         _tables = [
-            tables.table_change_schema(tables.ExperimentStatusTableV18),
-            tables.table_change_schema(tables.ExperimentStatusTable),
+            tables.table_change_schema(source=tables.ExperimentStatusTableV18),
+            tables.table_change_schema(source=tables.ExperimentStatusTable),
         ]
     else:
         # SQLite

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 from pydantic import BaseModel
 from sqlalchemy import Engine, Table, create_engine, delete, insert
-from sqlalchemy.schema import CreateTable
+from sqlalchemy.schema import CreateSchema, CreateTable
 
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.config.basicConfig import APIBasicConfig
@@ -67,6 +67,8 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
             self.table = valid_tables[0]
 
         with self.engine.connect() as conn:
+            if self.table.schema:
+                conn.execute(CreateSchema(self.table.schema, if_not_exists=True))
             conn.execute(CreateTable(self.table, if_not_exists=True))
             conn.commit()
 

--- a/autosubmit_api/repositories/join/experiment_join.py
+++ b/autosubmit_api/repositories/join/experiment_join.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import Column, Select, create_engine, or_, select
+from sqlalchemy import Column, Engine, Select, Table, create_engine, or_, select
 
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.database import tables
 from autosubmit_api.database.common import (
+    create_as_times_db_engine,
     create_main_db_conn,
     execute_with_limit_offset,
 )
@@ -32,17 +33,21 @@ def generate_query_listexp_extended(
     hpc: str = None,
     order_by: str = None,
     order_desc: bool = False,
+    status_table: Optional[Table] = None,
 ) -> Select:
     """
     Query listexp without accessing the view with status and total/completed jobs.
     """
 
+    if status_table is None:
+        status_table = tables.ExperimentStatusTable
+
     statement = (
         select(
             tables.ExperimentTable,
             tables.DetailsTable,
-            tables.ExperimentStatusTable.c.exp_id,
-            tables.ExperimentStatusTable.c.status,
+            status_table.c.exp_id,
+            status_table.c.status,
         )
         .join(
             tables.DetailsTable,
@@ -50,8 +55,8 @@ def generate_query_listexp_extended(
             isouter=True,
         )
         .join(
-            tables.ExperimentStatusTable,
-            tables.ExperimentTable.c.id == tables.ExperimentStatusTable.c.exp_id,
+            status_table,
+            tables.ExperimentTable.c.id == status_table.c.exp_id,
             isouter=True,
         )
     )
@@ -69,7 +74,7 @@ def generate_query_listexp_extended(
         )
 
     if only_active:
-        filter_stmts.append(tables.ExperimentStatusTable.c.status == "RUNNING")
+        filter_stmts.append(status_table.c.status == "RUNNING")
 
     if owner:
         filter_stmts.append(wildcard_search(owner, tables.DetailsTable.c.user))
@@ -140,10 +145,19 @@ class ExperimentJoinRepository(ABC):
 
 
 class ExperimentJoinSQLRepository(ExperimentJoinRepository):
+    def __init__(self, engine: Engine, valid_tables: List[Table]):
+        self.engine = engine
+        self.status_table = tables.check_table_schema(self.engine, valid_tables)
+        if self.status_table is None:
+            if len(valid_tables) == 0:
+                raise ValueError("No valid tables provided.")
+            # Fallback to the newest table
+            self.table = valid_tables[0]
+
     def _get_connection(self):
         if APIBasicConfig.DATABASE_BACKEND == "postgres":
             # PostgreSQL
-            return create_engine(APIBasicConfig.DATABASE_CONN_URL).connect()
+            return self.engine.connect()
         # SQLite
         return create_main_db_conn(read_only=False)
 
@@ -169,6 +183,7 @@ class ExperimentJoinSQLRepository(ExperimentJoinRepository):
             hpc=hpc,
             order_by=order_by,
             order_desc=order_desc,
+            status_table=self.status_table,
         )
         with self._get_connection() as conn:
             query_result, total_rows = execute_with_limit_offset(
@@ -179,11 +194,9 @@ class ExperimentJoinSQLRepository(ExperimentJoinRepository):
         return result, total_rows
 
     def drop_status_from_deleted_experiments(self) -> int:
-        from autosubmit_api.repositories.experiment_status import create_experiment_status_repository
-        status_table = create_experiment_status_repository().table
         with self._get_connection() as conn:
-            del_stmnt = status_table.delete().where(
-                status_table.c.exp_id.not_in(
+            del_stmnt = self.status_table.delete().where(
+                self.status_table.c.exp_id.not_in(
                     select(tables.ExperimentTable.c.id)
                 )
             )
@@ -194,4 +207,19 @@ class ExperimentJoinSQLRepository(ExperimentJoinRepository):
 
 
 def create_experiment_join_repository() -> ExperimentJoinRepository:
-    return ExperimentJoinSQLRepository()
+    if APIBasicConfig.DATABASE_BACKEND == "postgres":
+        # PostgreSQL
+        _engine = create_engine(APIBasicConfig.DATABASE_CONN_URL)
+        _tables = [
+            tables.table_change_schema("as_times", tables.ExperimentStatusTableV18),
+            tables.table_change_schema("as_times", tables.ExperimentStatusTable),
+        ]
+    else:
+        # SQLite
+        _engine = create_as_times_db_engine()
+        _tables = [
+            tables.ExperimentStatusTableV18,
+            tables.ExperimentStatusTable,
+        ]
+
+    return ExperimentJoinSQLRepository(engine=_engine, valid_tables=_tables)

--- a/autosubmit_api/repositories/join/experiment_join.py
+++ b/autosubmit_api/repositories/join/experiment_join.py
@@ -152,7 +152,7 @@ class ExperimentJoinSQLRepository(ExperimentJoinRepository):
             if len(valid_tables) == 0:
                 raise ValueError("No valid tables provided.")
             # Fallback to the newest table
-            self.table = valid_tables[0]
+            self.status_table = valid_tables[0]
 
     def _get_connection(self):
         if APIBasicConfig.DATABASE_BACKEND == "postgres":

--- a/autosubmit_api/repositories/join/experiment_join.py
+++ b/autosubmit_api/repositories/join/experiment_join.py
@@ -179,10 +179,11 @@ class ExperimentJoinSQLRepository(ExperimentJoinRepository):
         return result, total_rows
 
     def drop_status_from_deleted_experiments(self) -> int:
-        # TODO: Change permissions for deletion
+        from autosubmit_api.repositories.experiment_status import create_experiment_status_repository
+        status_table = create_experiment_status_repository().table
         with self._get_connection() as conn:
-            del_stmnt = tables.ExperimentStatusTable.delete().where(
-                tables.ExperimentStatusTable.c.exp_id.not_in(
+            del_stmnt = status_table.delete().where(
+                status_table.c.exp_id.not_in(
                     select(tables.ExperimentTable.c.id)
                 )
             )

--- a/autosubmit_api/repositories/join/experiment_join.py
+++ b/autosubmit_api/repositories/join/experiment_join.py
@@ -179,6 +179,7 @@ class ExperimentJoinSQLRepository(ExperimentJoinRepository):
         return result, total_rows
 
     def drop_status_from_deleted_experiments(self) -> int:
+        # TODO: Change permissions for deletion
         with self._get_connection() as conn:
             del_stmnt = tables.ExperimentStatusTable.delete().where(
                 tables.ExperimentStatusTable.c.exp_id.not_in(

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+import pytest
+
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.bgtasks.tasks.status_updater import StatusUpdater
 from autosubmit_api.history.database_managers.database_models import RunningStatus
@@ -232,7 +234,6 @@ class TestStatusUpdater:
         status = experiment_status_repo.get_by_expid(exp.name)
         assert status.status == RunningStatus.NOT_RUNNING
 
-
     def test_unparsable_heartbeat_falls_back_to_pickle(
         self, fixture_mock_basic_config, monkeypatch
     ):
@@ -262,7 +263,7 @@ class TestStatusUpdater:
         class MockJobsRepo:
             def get_last_modified_timestamp(self):
                 return int((now - timedelta(minutes=1)).timestamp())
-        
+
         monkeypatch.setattr(
             "autosubmit_api.bgtasks.tasks.status_updater.create_jobs_repository",
             lambda expid: MockJobsRepo(),
@@ -274,3 +275,59 @@ class TestStatusUpdater:
         # Unparsable heartbeat should fall back to pickle check, which is fresh, so stay as RUNNING
         assert status.status == RunningStatus.RUNNING
 
+    @pytest.mark.parametrize(
+        "upsert_error",
+        [False, True],
+        ids=[
+            "experiment status not found returns 0",
+            "upsert failure raises exception",
+        ],
+    )
+    def test_unsuccessfull_upsert(
+        self, fixture_mock_basic_config, monkeypatch, upsert_error, caplog
+    ):
+        """Test that if upsert fails, it's logged and if experiment status not found upsert return 0 and log a warning."""
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        experiments = experiment_repo.get_all()
+        assert len(experiments) >= 1
+
+        now = datetime.now(tz=LOCAL_TZ)
+
+        experiment_status_repo.delete_all()
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.time.time",
+            lambda: int(now.timestamp()),
+        )
+
+        def mock_upsert_status(*args, **kwargs):
+            if upsert_error:
+                raise Exception("Upsert failed")
+            else:
+                return 0
+
+        monkeypatch.setattr(
+            "autosubmit_api.repositories.experiment_status.ExperimentStatusSQLRepository.upsert_status",
+            mock_upsert_status,
+        )
+
+        # Run the updater with caplog to catch logs
+        # Act
+        caplog.clear()
+        StatusUpdater.run()
+
+        # Assert
+        if upsert_error:
+            # Exception raised by repository should be caught and logged as error
+            assert any(
+                rec.levelname == "ERROR" and "Upsert failed" in rec.message
+                for rec in caplog.records
+            )
+        else:
+            # Upsert returning 0 should log a warning about rejected update
+            assert any(
+                rec.levelname == "WARNING" and "Status update rejected" in rec.message
+                for rec in caplog.records
+            )

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -275,6 +275,51 @@ class TestStatusUpdater:
         # Unparsable heartbeat should fall back to pickle check, which is fresh, so stay as RUNNING
         assert status.status == RunningStatus.RUNNING
 
+    def test_stale_heartbeat_with_old_pkl_age_calls_is_exp_running(
+        self, fixture_mock_basic_config, monkeypatch
+    ):
+        """Test that if last_heartbeat is stale and pkl_age is 1000 it 
+        enters the exhaustive check branch and keeps experiment as RUNNING."""
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        experiments = experiment_repo.get_all()
+        assert len(experiments) >= 1
+        exp = experiments[0]
+
+        now = datetime.now(tz=LOCAL_TZ)
+        stale_heartbeat = (
+            now - timedelta(minutes=3)
+        ).isoformat()  # 3 min old > 150s threshold
+
+        experiment_status_repo.delete_all()
+        experiment_status_repo.upsert_status(
+            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=stale_heartbeat
+        )
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.time.time",
+            lambda: int(now.timestamp()),
+        )
+
+        # Mock create_jobs_repository to return an old pickle
+        # 11 minutes old > 10 min threshold, but < 1 hour exhaustive search
+        class MockJobsRepo:
+            def get_last_modified_timestamp(self):
+                return int((now - timedelta(minutes=11)).timestamp())
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.create_jobs_repository",
+            lambda expid: MockJobsRepo(),
+        )
+
+        StatusUpdater.run()
+
+        status = experiment_status_repo.get_by_expid(exp.name)
+        # Stale heartbeat with old pickle should enter exhaustive check
+        # Since we mock _check_exp_running to return True, it should stay as RUNNING
+        assert status.status == RunningStatus.RUNNING
+
     @pytest.mark.parametrize(
         "upsert_error",
         [False, True],

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import pytest
 
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.bgtasks.tasks.status_updater import StatusUpdater
@@ -45,17 +44,20 @@ class TestStatusUpdater:
         experiment_status_repo.upsert_status(2, "a007", RunningStatus.NOT_RUNNING)
         experiment_status_repo.upsert_status(3, "a3tb", RunningStatus.ARCHIVED)
         experiment_status_repo.upsert_status(4, "a3t2", RunningStatus.DELETED)
+        experiment_status_repo.upsert_status(5, "a5xx", "")
 
         statuses = StatusUpdater._get_mutable_statuses()
 
-        assert set(statuses.keys()) == {"a003"}
+        assert set(statuses.keys()) == {"a003", "a5xx"}
         assert statuses["a003"].status == RunningStatus.RUNNING
+        assert statuses["a5xx"].status == ""
 
     def test_missing_experiments_are_initialized_as_not_running(
         self, fixture_mock_basic_config, monkeypatch
     ):
         """Test that experiments missing from the status table are initialized with NOT_RUNNING status."""
         # TODO: This tests needs to be changed for issue #287
+        # In future implmementations, not all missing statuses will be initialized as NOT_RUNNING
         experiment_repo = create_experiment_repository()
         experiment_status_repo = create_experiment_status_repository()
 
@@ -73,7 +75,7 @@ class TestStatusUpdater:
         assert set(x.name for x in experiments) == set(x.name for x in exps_status)
         assert all(x.status == RunningStatus.NOT_RUNNING for x in exps_status)
 
-    def test_mutable_experiments_are_re_evaluated(
+    def test_only_mutable_experiments_are_re_evaluated(
         self, fixture_mock_basic_config, monkeypatch
     ):
         """Test that experiments with mutable statuses are re-evaluated and updated and experiments with terminal statuses are not re-evaluated.
@@ -120,11 +122,7 @@ class TestStatusUpdater:
         monkeypatch.setattr(
             StatusUpdater,
             "_check_exp_running",
-            classmethod(
-                lambda cls, expid, status_row=None: fake_check_exp_running(
-                    expid, status_row
-                )
-            ),
+            fake_check_exp_running,
         )
 
         StatusUpdater.run()

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -313,9 +313,8 @@ class TestStatusUpdater:
         StatusUpdater.run()
 
         status = experiment_status_repo.get_by_expid(exp.name)
-        # Stale heartbeat with old pickle should enter exhaustive check
+        # Empty heartbeat with old pickle should enter exhaustive check
         # And keep experiment as RUNNING since it's still < 1 hour old
-
         assert status.status == RunningStatus.RUNNING
 
     @pytest.mark.parametrize(
@@ -467,3 +466,50 @@ class TestStatusUpdater:
             and "Database error during status update" in rec.message
             for rec in caplog.records
         )
+
+def test_experiment_in_status_table_not_in_experiment_table(
+    self, fixture_mock_basic_config, monkeypatch, caplog
+):
+    """Test that if an experiment is in the status table but 
+    not in the experiment table, a warning is logged and the 
+    execution continues."""
+    experiment_repo = create_experiment_repository()
+    experiment_status_repo = create_experiment_status_repository()
+
+    # Get real experiments and clear status table
+    all_experiments = experiment_repo.get_all()
+    experiment_status_repo.delete_all()
+
+    # Generate a fake experiment name not present in the experiment table
+    fake_exp_name = "fake_exp"
+
+    # Add it to the status table with a mutable status (RUNNING)
+    experiment_status_repo.upsert_status(
+        exp_id=9999, name=fake_exp_name, status=RunningStatus.RUNNING
+    )
+
+    # Mock _check_exp_running to ensure it's not called
+    call_count = [0]
+    def mock_check_exp_running(expid, status_row=None):
+        call_count[0] += 1
+        return False
+
+    monkeypatch.setattr(
+        StatusUpdater,
+        "_check_exp_running",
+        mock_check_exp_running,
+    )
+
+    # Run the updater
+    caplog.clear()
+    StatusUpdater.run()
+
+    # Assert warning logged
+    assert any(
+        rec.levelname == "WARNING"
+        and "found in status table but not in experiments table" in rec.message
+        for rec in caplog.records
+    )
+
+    # Verify _check_exp_running was not called
+    assert call_count[0] == 0

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+import pytest
+
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.bgtasks.tasks.status_updater import StatusUpdater
 from autosubmit_api.history.database_managers.database_models import RunningStatus
@@ -46,8 +48,10 @@ class TestStatusUpdater:
         experiment_status_repo.upsert_status(4, "a3t2", RunningStatus.DELETED)
         experiment_status_repo.upsert_status(5, "a5xx", "")
 
+        # Act
         statuses = StatusUpdater._get_mutable_statuses()
 
+        # Assert
         assert set(statuses.keys()) == {"a003", "a5xx"}
         assert statuses["a003"].status == RunningStatus.RUNNING
         assert statuses["a5xx"].status == ""
@@ -75,10 +79,11 @@ class TestStatusUpdater:
         assert set(x.name for x in experiments) == set(x.name for x in exps_status)
         assert all(x.status == RunningStatus.NOT_RUNNING for x in exps_status)
 
-    def test_only_mutable_experiments_are_re_evaluated(
+    def test_only_mutable_experiments_are_evaluated(
         self, fixture_mock_basic_config, monkeypatch
     ):
-        """Test that experiments with mutable statuses are re-evaluated and updated and experiments with terminal statuses are not re-evaluated.
+        """Test that experiments with mutable statuses are evaluated
+        and experiments with terminal statuses are not evaluated.
         RUNNING and "" statuses are mutable, while NOT_RUNNING, ARCHIVED and DELETED are terminal.
         """
         experiment_repo = create_experiment_repository()
@@ -110,7 +115,7 @@ class TestStatusUpdater:
 
         checked_experiments = []
 
-        def fake_check_exp_running(expid, status_row=None):
+        def _mock_check_exp_running(expid, status_row=None):
             checked_experiments.append(expid)
             if expid == running_exp.name:
                 return True
@@ -122,7 +127,7 @@ class TestStatusUpdater:
         monkeypatch.setattr(
             StatusUpdater,
             "_check_exp_running",
-            fake_check_exp_running,
+            _mock_check_exp_running,
         )
 
         StatusUpdater.run()
@@ -156,7 +161,7 @@ class TestStatusUpdater:
             == RunningStatus.NOT_RUNNING
         )
 
-    def test_check_exp_running_prioritizes_heartbeat_order(
+    def test_check_exp_running_prioritizes_heartbeat_over_pkl(
         self, fixture_mock_basic_config, monkeypatch
     ):
         """Test that _check_exp_running prioritizes heartbeat age over pkl age."""
@@ -228,3 +233,46 @@ class TestStatusUpdater:
 
         status = experiment_status_repo.get_by_expid(exp.name)
         assert status.status == RunningStatus.NOT_RUNNING
+
+
+    def test_unparsable_heartbeat_falls_back_to_pickle(
+        self, fixture_mock_basic_config, monkeypatch
+    ):
+        """Test that if last_heartbeat is unparsable, it falls back to checking the pickle file."""
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        experiments = experiment_repo.get_all()
+        assert len(experiments) >= 1
+        exp = experiments[0]
+
+        now = datetime.now(tz=LOCAL_TZ)
+        unparsable_heartbeat = "not-a-timestamp"
+
+        experiment_status_repo.delete_all()
+        experiment_status_repo.upsert_status(
+            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=unparsable_heartbeat
+        )
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.time.time",
+            lambda: int(now.timestamp()),
+        )
+
+        # Mock create_jobs_repository to return fresh pickle
+        # 1 min old < 10 min threshold
+        class MockJobsRepo:
+            def get_last_modified_timestamp(self):
+                return int((now - timedelta(minutes=1)).timestamp())
+        
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.create_jobs_repository",
+            lambda expid: MockJobsRepo(),
+        )
+
+        StatusUpdater.run()
+
+        status = experiment_status_repo.get_by_expid(exp.name)
+        # Unparsable heartbeat should fall back to pickle check, which is fresh, so stay as RUNNING
+        assert status.status == RunningStatus.RUNNING
+

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -275,7 +275,7 @@ class TestStatusUpdater:
         # Unparsable heartbeat should fall back to pickle check, which is fresh, so stay as RUNNING
         assert status.status == RunningStatus.RUNNING
 
-    def test_stale_heartbeat_with_old_pkl_age_calls_is_exp_running(
+    def test_stale_heartbeat_with_old_pkl_calls_is_exp_running(
         self, fixture_mock_basic_config, monkeypatch
     ):
         """Test that if last_heartbeat is stale and pkl_age is 1000 it 
@@ -318,10 +318,7 @@ class TestStatusUpdater:
         status = experiment_status_repo.get_by_expid(exp.name)
         # Stale heartbeat with old pickle should enter exhaustive check
         # And keep experiment as RUNNING since it's still < 1 hour old
-        if fixture_mock_basic_config == "fixture_sqlite":
-            assert status.status == RunningStatus.RUNNING
-        if fixture_mock_basic_config == "fixture_postgres":
-            assert status.status == RunningStatus.NOT_RUNNING
+        assert status.status == RunningStatus.RUNNING
 
     @pytest.mark.parametrize(
         "upsert_error",

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timedelta
+import pytest
+
+from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.bgtasks.tasks.status_updater import StatusUpdater
 from autosubmit_api.history.database_managers.database_models import RunningStatus
 from autosubmit_api.repositories.experiment import create_experiment_repository
-from autosubmit_api.repositories.experiment_status import create_experiment_status_repository
-
+from autosubmit_api.repositories.experiment_status import (
+    create_experiment_status_repository,
+    ExperimentStatusModel,
+)
 
 class TestStatusUpdater:
     def test_same_tables(self, fixture_mock_basic_config):
@@ -27,3 +33,200 @@ class TestStatusUpdater:
 
         for e_st in exps_status:
             assert e_st.status in [RunningStatus.RUNNING, RunningStatus.NOT_RUNNING]
+
+    def test_get_mutable_status_filters_terminal_statuses(
+        self, fixture_mock_basic_config
+    ):
+        """Test _get_mutable_statuses excludes NOT_RUNNING, ARCHIVED and DELETED statuses."""
+        experiment_status_repo = create_experiment_status_repository()
+        experiment_status_repo.delete_all()
+
+        experiment_status_repo.upsert_status(1, "a003", RunningStatus.RUNNING)
+        experiment_status_repo.upsert_status(2, "a007", RunningStatus.NOT_RUNNING)
+        experiment_status_repo.upsert_status(3, "a3tb", RunningStatus.ARCHIVED)
+        experiment_status_repo.upsert_status(4, "a3t2", RunningStatus.DELETED)
+
+        statuses = StatusUpdater._get_mutable_statuses()
+
+        assert set(statuses.keys()) == {"a003"}
+        assert statuses["a003"].status == RunningStatus.RUNNING
+
+    def test_missing_experiments_are_initialized_as_not_running(
+        self, fixture_mock_basic_config, monkeypatch
+    ):
+        """Test that experiments missing from the status table are initialized with NOT_RUNNING status."""
+        # TODO: This tests needs to be changed for issue #287
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        # Delete all experiment statuses entries, but not experiments
+        experiment_status_repo.delete_all()
+        experiments = experiment_repo.get_all()
+        assert len(experiments) > 0
+
+        StatusUpdater.run()
+
+        exps_status = experiment_status_repo.get_all()
+
+        assert len(experiments) == len(exps_status)
+        assert set(x.id for x in experiments) == set(x.exp_id for x in exps_status)
+        assert set(x.name for x in experiments) == set(x.name for x in exps_status)
+        assert all(x.status == RunningStatus.NOT_RUNNING for x in exps_status)
+
+    def test_mutable_experiments_are_re_evaluated(
+        self, fixture_mock_basic_config, monkeypatch
+    ):
+        """Test that experiments with mutable statuses are re-evaluated and updated and experiments with terminal statuses are not re-evaluated.
+        RUNNING and "" statuses are mutable, while NOT_RUNNING, ARCHIVED and DELETED are terminal.
+        """
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        experiments = experiment_repo.get_all()
+        assert len(experiments) >= 5
+
+        running_exp = experiments[0]
+        empty_exp = experiments[1]
+        archived_exp = experiments[2]
+        deleted_exp = experiments[3]
+        not_running_exp = experiments[4]
+
+        experiment_status_repo.delete_all()
+        experiment_status_repo.upsert_status(
+            running_exp.id, running_exp.name, RunningStatus.RUNNING
+        )
+        experiment_status_repo.upsert_status(empty_exp.id, empty_exp.name, "")
+        experiment_status_repo.upsert_status(
+            archived_exp.id, archived_exp.name, RunningStatus.ARCHIVED
+        )
+        experiment_status_repo.upsert_status(
+            deleted_exp.id, deleted_exp.name, RunningStatus.DELETED
+        )
+        experiment_status_repo.upsert_status(
+            not_running_exp.id, not_running_exp.name, RunningStatus.NOT_RUNNING
+        )
+
+        checked_experiments = []
+
+        def fake_check_exp_running(expid, status_row=None):
+            checked_experiments.append(expid)
+            if expid == running_exp.name:
+                return True
+            elif expid == empty_exp.name:
+                return False
+            else:
+                raise ValueError(f"Unexpected experiment name: {expid}")
+
+        monkeypatch.setattr(
+            StatusUpdater,
+            "_check_exp_running",
+            classmethod(
+                lambda cls, expid, status_row=None: fake_check_exp_running(
+                    expid, status_row
+                )
+            ),
+        )
+
+        StatusUpdater.run()
+
+        # Mutable statuses must have been checked
+        assert set(checked_experiments) == {running_exp.name, empty_exp.name}
+        # Terminal statuses must not have been checked
+        assert archived_exp.name not in checked_experiments
+        assert deleted_exp.name not in checked_experiments
+        assert not_running_exp.name not in checked_experiments
+
+        # Statuses must have been updated according to the fake_check_exp_running logic
+        assert (
+            experiment_status_repo.get_by_expid(running_exp.name).status
+            == RunningStatus.RUNNING
+        )
+        assert (
+            experiment_status_repo.get_by_expid(empty_exp.name).status
+            == RunningStatus.NOT_RUNNING
+        )
+        assert (
+            experiment_status_repo.get_by_expid(archived_exp.name).status
+            == RunningStatus.ARCHIVED
+        )
+        assert (
+            experiment_status_repo.get_by_expid(deleted_exp.name).status
+            == RunningStatus.DELETED
+        )
+        assert (
+            experiment_status_repo.get_by_expid(not_running_exp.name).status
+            == RunningStatus.NOT_RUNNING
+        )
+
+    def test_check_exp_running_prioritizes_heartbeat_order(
+        self, fixture_mock_basic_config, monkeypatch
+    ):
+        """Test that _check_exp_running prioritizes heartbeat age over pkl age."""
+        now = datetime.now(tz=LOCAL_TZ)
+        fresh_heartbeat = (now - timedelta(minutes=1)).isoformat()
+
+        status_row = ExperimentStatusModel(
+            exp_id=1,
+            name="a003",
+            status=RunningStatus.RUNNING,
+            seconds_diff=0,
+            modified=now.isoformat(),
+            last_heartbeat=fresh_heartbeat,
+        )
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.time.time",
+            lambda: int(now.timestamp()),
+        )
+
+        def _should_not_be_called(_):
+            raise AssertionError("create_jobs_repository should not be called")
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.create_jobs_repository",
+            _should_not_be_called,
+        )
+
+        assert StatusUpdater._check_exp_running("a003", status_row) is True
+
+    def test_stale_heartbeat_changes_running_to_not_running(
+        self, fixture_mock_basic_config, monkeypatch
+    ):
+        """Test that RUNNING experiment with stale heartbeat become NOT_RUNNING."""
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        experiments = experiment_repo.get_all()
+        assert len(experiments) >= 1
+        exp = experiments[0]
+
+        now = datetime.now(tz=LOCAL_TZ)
+        stale_heartbeat = (
+            now - timedelta(minutes=3)
+        ).isoformat()  # 3 min old > 150s threshold
+
+        experiment_status_repo.delete_all()
+        experiment_status_repo.upsert_status(
+            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=stale_heartbeat
+        )
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.time.time",
+            lambda: int(now.timestamp()),
+        )
+
+        # Mock create_jobs_repository to avoid pickle checks. This is tested in other unit tests
+        def mock_jobs_repo(expid):
+            raise AssertionError(
+                "Should not reach pickle check if last_heartbeat is present"
+            )
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.create_jobs_repository",
+            mock_jobs_repo,
+        )
+
+        StatusUpdater.run()
+
+        status = experiment_status_repo.get_by_expid(exp.name)
+        assert status.status == RunningStatus.NOT_RUNNING

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -361,3 +361,38 @@ class TestStatusUpdater:
         # Assert that it returns early: status table should still be empty
         statuses = experiment_status_repo.get_all()
         assert len(statuses) == 0
+
+    def test_set_status_repository_get_all_logs_error_when_raises_exception(
+        self, fixture_mock_basic_config, monkeypatch, caplog
+    ):
+        """Test that if _get_all raises an exception, it is logged and the updater exists early."""
+        experiment_status_repo = create_experiment_status_repository()
+        experiment_status_repo.delete_all()
+
+        # Mock _get_all to raise an exception
+        def mock_create():
+            repo = create_experiment_status_repository()
+            def mock_get_all():
+                raise Exception("Database error during get_all")
+            repo.get_all = mock_get_all
+            return repo
+
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.create_experiment_status_repository",
+            mock_create
+        )
+
+        # Run the updater with caplog to catch logs
+        # Act
+        caplog.clear()
+        StatusUpdater.run()
+
+        # Assert
+        assert any(
+            rec.levelname == "ERROR" and "Database error during get_all" in rec.message
+            for rec in caplog.records
+        )
+
+        # Assert that it returns early: status table should still be empty
+        statuses = experiment_status_repo.get_all()
+        assert len(statuses) == 0

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -396,3 +396,45 @@ class TestStatusUpdater:
         # Assert that it returns early: status table should still be empty
         statuses = experiment_status_repo.get_all()
         assert len(statuses) == 0
+
+    def test_update_experiment_status_logs_error_when_upsert_fails(
+        self, fixture_mock_basic_config, monkeypatch, caplog
+    ):
+        """Test that if upsert_status raises an exception during status update, 
+        it is logged as an error and the updater continues updating other experiments."""
+        experiment_repo = create_experiment_repository()
+        experiment_status_repo = create_experiment_status_repository()
+
+        experiments = experiment_repo.get_all()
+        assert len(experiments) >= 1
+        exp = experiments[0]
+
+        now = datetime.now(tz=LOCAL_TZ)
+
+        experiment_status_repo.delete_all()
+        experiment_status_repo.upsert_status(
+            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=now.isoformat()
+        )
+
+        # Mock upsert_status to raise an exception for a specific experiment
+        def mock_create():
+            repo = create_experiment_status_repository()
+            def mock_upsert_status(*args, **kwargs):
+                raise Exception("Database error during upsert")
+            repo.upsert_status = mock_upsert_status
+            return repo
+        monkeypatch.setattr(
+            "autosubmit_api.bgtasks.tasks.status_updater.create_experiment_status_repository",
+            mock_create
+        )
+
+        # Run the updater with caplog to catch logs
+        # Act
+        caplog.clear()
+        StatusUpdater.run()
+
+        # Assert
+        assert any(
+            rec.levelname == "ERROR" and "Database error during upsert" in rec.message
+            for rec in caplog.records
+        )

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timedelta
 
-import pytest
-
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.bgtasks.tasks.status_updater import StatusUpdater
 from autosubmit_api.history.database_managers.database_models import RunningStatus

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -317,8 +317,11 @@ class TestStatusUpdater:
 
         status = experiment_status_repo.get_by_expid(exp.name)
         # Stale heartbeat with old pickle should enter exhaustive check
-        # Since we mock _check_exp_running to return True, it should stay as RUNNING
-        assert status.status == RunningStatus.RUNNING
+        # And keep experiment as RUNNING since it's still < 1 hour old
+        if fixture_mock_basic_config == "fixture_sqlite":
+            assert status.status == RunningStatus.RUNNING
+        if fixture_mock_basic_config == "fixture_postgres":
+            assert status.status == RunningStatus.NOT_RUNNING
 
     @pytest.mark.parametrize(
         "upsert_error",

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -397,35 +397,20 @@ class TestStatusUpdater:
         statuses = experiment_status_repo.get_all()
         assert len(statuses) == 0
 
-    def test_update_experiment_status_logs_error_when_upsert_fails(
+    def test_update_experiment_status_logs_error_when_raises_exception(
         self, fixture_mock_basic_config, monkeypatch, caplog
     ):
-        """Test that if upsert_status raises an exception during status update, 
-        it is logged as an error and the updater continues updating other experiments."""
-        experiment_repo = create_experiment_repository()
+        """Test that if _update_experiment_status raises an exception, 
+        it is logged and continues the execution"""
         experiment_status_repo = create_experiment_status_repository()
-
-        experiments = experiment_repo.get_all()
-        assert len(experiments) >= 1
-        exp = experiments[0]
-
-        now = datetime.now(tz=LOCAL_TZ)
-
         experiment_status_repo.delete_all()
-        experiment_status_repo.upsert_status(
-            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=now.isoformat()
-        )
 
-        # Mock upsert_status to raise an exception for a specific experiment
-        def mock_create():
-            repo = create_experiment_status_repository()
-            def mock_upsert_status(*args, **kwargs):
-                raise Exception("Database error during upsert")
-            repo.upsert_status = mock_upsert_status
-            return repo
+        # Mock _update_experiment_status to raise an exception
+        def mock_update_experiment_status(expid, is_running=False, status_row=None):
+            raise Exception("Database error during status update")
+
         monkeypatch.setattr(
-            "autosubmit_api.bgtasks.tasks.status_updater.create_experiment_status_repository",
-            mock_create
+            StatusUpdater, "_update_experiment_status", mock_update_experiment_status
         )
 
         # Run the updater with caplog to catch logs
@@ -435,6 +420,7 @@ class TestStatusUpdater:
 
         # Assert
         assert any(
-            rec.levelname == "ERROR" and "Database error during upsert" in rec.message
+            rec.levelname == "ERROR"
+            and "Database error during status update" in rec.message
             for rec in caplog.records
         )

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -286,15 +286,12 @@ class TestStatusUpdater:
         experiments = experiment_repo.get_all()
         assert len(experiments) >= 1
         exp = experiments[0]
-
         now = datetime.now(tz=LOCAL_TZ)
-        stale_heartbeat = (
-            now - timedelta(minutes=3)
-        ).isoformat()  # 3 min old > 150s threshold
+        empty_heartbeat = ""
 
         experiment_status_repo.delete_all()
         experiment_status_repo.upsert_status(
-            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=stale_heartbeat
+            exp.id, exp.name, RunningStatus.RUNNING, last_heartbeat=empty_heartbeat
         )
 
         monkeypatch.setattr(
@@ -318,6 +315,7 @@ class TestStatusUpdater:
         status = experiment_status_repo.get_by_expid(exp.name)
         # Stale heartbeat with old pickle should enter exhaustive check
         # And keep experiment as RUNNING since it's still < 1 hour old
+
         assert status.status == RunningStatus.RUNNING
 
     @pytest.mark.parametrize(

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -11,6 +11,7 @@ from autosubmit_api.repositories.experiment_status import (
     ExperimentStatusModel,
 )
 
+
 class TestStatusUpdater:
     def test_same_tables(self, fixture_mock_basic_config):
         experiment_repo = create_experiment_repository()
@@ -278,7 +279,7 @@ class TestStatusUpdater:
     def test_stale_heartbeat_with_old_pkl_calls_is_exp_running(
         self, fixture_mock_basic_config, monkeypatch
     ):
-        """Test that if last_heartbeat is stale and pkl_age is 1000 it 
+        """Test that if last_heartbeat is stale and pkl_age is 1000 it
         enters the exhaustive check branch and keeps experiment as RUNNING."""
         experiment_repo = create_experiment_repository()
         experiment_status_repo = create_experiment_status_repository()
@@ -414,14 +415,16 @@ class TestStatusUpdater:
         # Mock _get_all to raise an exception
         def mock_create():
             repo = create_experiment_status_repository()
+
             def mock_get_all():
                 raise Exception("Database error during get_all")
+
             repo.get_all = mock_get_all
             return repo
 
         monkeypatch.setattr(
             "autosubmit_api.bgtasks.tasks.status_updater.create_experiment_status_repository",
-            mock_create
+            mock_create,
         )
 
         # Run the updater with caplog to catch logs
@@ -442,7 +445,7 @@ class TestStatusUpdater:
     def test_update_experiment_status_logs_error_when_raises_exception(
         self, fixture_mock_basic_config, monkeypatch, caplog
     ):
-        """Test that if _update_experiment_status raises an exception, 
+        """Test that if _update_experiment_status raises an exception,
         it is logged and continues the execution"""
         experiment_status_repo = create_experiment_status_repository()
         experiment_status_repo.delete_all()
@@ -466,50 +469,3 @@ class TestStatusUpdater:
             and "Database error during status update" in rec.message
             for rec in caplog.records
         )
-
-def test_experiment_in_status_table_not_in_experiment_table(
-    self, fixture_mock_basic_config, monkeypatch, caplog
-):
-    """Test that if an experiment is in the status table but 
-    not in the experiment table, a warning is logged and the 
-    execution continues."""
-    experiment_repo = create_experiment_repository()
-    experiment_status_repo = create_experiment_status_repository()
-
-    # Get real experiments and clear status table
-    all_experiments = experiment_repo.get_all()
-    experiment_status_repo.delete_all()
-
-    # Generate a fake experiment name not present in the experiment table
-    fake_exp_name = "fake_exp"
-
-    # Add it to the status table with a mutable status (RUNNING)
-    experiment_status_repo.upsert_status(
-        exp_id=9999, name=fake_exp_name, status=RunningStatus.RUNNING
-    )
-
-    # Mock _check_exp_running to ensure it's not called
-    call_count = [0]
-    def mock_check_exp_running(expid, status_row=None):
-        call_count[0] += 1
-        return False
-
-    monkeypatch.setattr(
-        StatusUpdater,
-        "_check_exp_running",
-        mock_check_exp_running,
-    )
-
-    # Run the updater
-    caplog.clear()
-    StatusUpdater.run()
-
-    # Assert warning logged
-    assert any(
-        rec.levelname == "WARNING"
-        and "found in status table but not in experiments table" in rec.message
-        for rec in caplog.records
-    )
-
-    # Verify _check_exp_running was not called
-    assert call_count[0] == 0

--- a/tests/bgtasks/test_status_updater.py
+++ b/tests/bgtasks/test_status_updater.py
@@ -331,3 +331,33 @@ class TestStatusUpdater:
                 rec.levelname == "WARNING" and "Status update rejected" in rec.message
                 for rec in caplog.records
             )
+
+    def test_clear_missing_experiments_logs_warning_when_raises_exception(
+        self, fixture_mock_basic_config, monkeypatch, caplog
+    ):
+        """Test that if _clear_missing_experiments raises an exception, it's logged as a warning and exits early."""
+        experiment_status_repo = create_experiment_status_repository()
+        experiment_status_repo.delete_all()
+
+        # Mock _clear_missing_experiments to raise an exception
+        def mock_clear_missing_experiments():
+            raise Exception("Database error during clear")
+
+        monkeypatch.setattr(
+            StatusUpdater, "_clear_missing_experiments", mock_clear_missing_experiments
+        )
+
+        # Run the updater with caplog to catch logs
+        # Act
+        caplog.clear()
+        StatusUpdater.run()
+
+        # Assert
+        assert any(
+            rec.levelname == "ERROR" and "Database error during clear" in rec.message
+            for rec in caplog.records
+        )
+
+        # Assert that it returns early: status table should still be empty
+        statuses = experiment_status_repo.get_all()
+        assert len(statuses) == 0

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -198,7 +198,6 @@ class TestExperimentStatusRepository:
         )
 
         row = experiment_status_db.get_by_expid("a003")
-        assert row.last_heartbeat == heartbeat
         assert row.status == "RUNNING"
         assert row.name == "a003"
         assert row.exp_id == 1

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from typing import Any, Dict, List
 from uuid import uuid4
 
 import pytest
+from autosubmit_api.common.utils import LOCAL_TZ
 
 from autosubmit_api.repositories.experiment import create_experiment_repository
 from autosubmit_api.repositories.experiment_status import (
@@ -182,6 +184,29 @@ class TestExperimentStatusRepository:
         # Assert only_running
         only_running = experiment_status_db.get_only_running_expids()
         assert set(only_running) == {"a3tb"}
+
+    def test_last_heartbeat_traceability(self, fixture_mock_basic_config):
+        """Test that last_heartbeat can be stored and retrieved correctly 
+        and that it is None if the column does not exist."""
+        experiment_status_db = create_experiment_status_repository()
+
+        experiment_status_db.delete_all()
+
+        heartbeat = datetime.now(tz=LOCAL_TZ).isoformat(sep="-", timespec="seconds")
+        experiment_status_db.upsert_status(
+            1, "a003", "RUNNING", last_heartbeat=heartbeat
+        )
+
+        row = experiment_status_db.get_by_expid("a003")
+        assert row.last_heartbeat == heartbeat
+        assert row.status == "RUNNING"
+        assert row.name == "a003"
+        assert row.exp_id == 1
+
+        if "last_heartbeat" in experiment_status_db.table.c:
+            assert row.last_heartbeat == heartbeat
+        else:
+            assert row.last_heartbeat is None
 
 
 class TestExpGraphLayoutRepository:

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from autosubmit_api.common.utils import LOCAL_TZ
 
+from autosubmit_api.database import tables
 from autosubmit_api.repositories.experiment import create_experiment_repository
 from autosubmit_api.repositories.experiment_status import (
     create_experiment_status_repository,
@@ -13,6 +14,7 @@ from autosubmit_api.repositories.experiment_status import (
 )
 from autosubmit_api.repositories.graph_layout import create_exp_graph_layout_repository
 from autosubmit_api.repositories.join.experiment_join import (
+    ExperimentJoinSQLRepository,
     create_experiment_join_repository,
     generate_query_listexp_extended,
 )
@@ -281,6 +283,32 @@ class TestExperimentRunnerRepository:
 
 
 class TestExperimentJoinRepository:
+    def test_init_no_tables_raises(self):
+        """Tests that ExperimentJoinSQLRepository raises ValueError if no valid tables are provided."""
+        engine = create_engine("sqlite:///:memory:")
+        
+        with pytest.raises(ValueError):
+            ExperimentJoinSQLRepository(engine, [])
+    
+    def test_init_falls_to_newest_table_when_schema_unknown(self, monkeypatch: pytest.MonkeyPatch):
+        """Tests that ExperimentJoinSQLRepository falls back to the newest table if no table has the expected schema."""
+        engine = create_engine("sqlite:///:memory:")
+        valid_tables = [tables.ExperimentStatusTableV18, tables.ExperimentStatusTable]
+        
+        # mock experiment_join_tables.check_table_schema to return None. 
+        # We want to simulate the case where the schema of the tables in the 
+        # database does not match any of the valid tables provided.
+        monkeypatch.setattr(
+            "autosubmit_api.repositories.join.experiment_join.tables.check_table_schema",
+            lambda _engine, _valid_tables: None,
+        )
+
+        # Act
+        experiment_join_repo = ExperimentJoinSQLRepository(engine, valid_tables)
+
+        # Assert
+        assert experiment_join_repo.status_table == valid_tables[0]
+
     def test_drop_status_from_deleted_experiments(self, fixture_mock_basic_config):
         experiment_join_repo = create_experiment_join_repository()
         experiment_status_repo = create_experiment_status_repository()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -3,11 +3,13 @@ from typing import Any, Dict, List
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import create_engine
 from autosubmit_api.common.utils import LOCAL_TZ
 
 from autosubmit_api.repositories.experiment import create_experiment_repository
 from autosubmit_api.repositories.experiment_status import (
     create_experiment_status_repository,
+    ExperimentStatusSQLRepository,
 )
 from autosubmit_api.repositories.graph_layout import create_exp_graph_layout_repository
 from autosubmit_api.repositories.join.experiment_join import (
@@ -206,6 +208,12 @@ class TestExperimentStatusRepository:
             assert row.last_heartbeat == heartbeat
         else:
             assert row.last_heartbeat is None
+
+    def test_init_no_tables_raises(self):
+        """Tests that ExperimentStatusSQLRepository raises ValueERror if no valid tables are provided."""
+        engine = create_engine("sqlite:///:memory:")
+        with pytest.raises(ValueError):
+            ExperimentStatusSQLRepository(engine, [])
 
 
 class TestExpGraphLayoutRepository:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -120,8 +120,15 @@ def copy_autosubmit_db(filepath: str, engine: Engine):
 def copy_as_times_db(filepath: str, engine: Engine):
     source_as_db = create_engine(f"sqlite:///{filepath}")
     with source_as_db.connect() as source_conn, engine.connect() as conn:
+        experiment_status_table = tables.check_table_schema(
+            source_as_db, [tables.ExperimentStatusTableV18, tables.ExperimentStatusTable]
+        )
         _copy_table_data(
-            source_conn, conn, None, tables.ExperimentStatusTable, schema_required=False
+            source_conn,
+            conn,
+            None,
+            experiment_status_table,
+            schema_required=False,
         )
         conn.commit()
 


### PR DESCRIPTION
Closes #282 
PR to trace the experiment statuses from the database instead of pkl files. Force the db to be the first source of truth (while keeping the pkl status compatibility as a recovery approach)