### PR TITLE
Add generalized upsert

### DIFF
--- a/autosubmit_api/bgtasks/tasks/details_updater.py
+++ b/autosubmit_api/bgtasks/tasks/details_updater.py
@@ -55,7 +55,7 @@ class PopulateDetailsDB(BackgroundTaskTemplate):
 
     @classmethod
     def _build_details_data_from_experiment(
-        self, exp_id: int, expid: str
+        cls, exp_id: int, expid: str
     ) -> ExperimentDetailsModel:
         """
         Build the details data from the experiment

--- a/autosubmit_api/database/common.py
+++ b/autosubmit_api/database/common.py
@@ -163,6 +163,9 @@ def execute_upsert(
         _insert = sqlite_insert
     else:
         # Fallback for unsupported dialects - this will not perform an atomic upsert, so use with caution.
+        logger.debug(
+            f"Dialect '{dialect}' native upsert not supported or not implemented. Performing non-atomic upsert as fallback."
+        )
         existing = conn.execute(
             select(table).where(
                 *[table.c[el] == values[el] for el in str_index_elements]

--- a/autosubmit_api/database/common.py
+++ b/autosubmit_api/database/common.py
@@ -1,18 +1,25 @@
 import os
-from typing import Any
+from typing import Any, Dict, List, Union
+
 from sqlalchemy import (
+    Column,
     Connection,
     Engine,
     NullPool,
     Select,
+    Table,
     create_engine,
+    func,
+    insert,
     select,
     text,
-    func,
 )
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
 from autosubmit_api.builders import BaseBuilder
-from autosubmit_api.logger import logger
 from autosubmit_api.config.basicConfig import APIBasicConfig
+from autosubmit_api.logger import logger
 
 
 class AttachedDatabaseConnBuilder(BaseBuilder):
@@ -116,3 +123,67 @@ def execute_with_limit_offset(
     total = conn.scalar(count_stmnt)
 
     return query_result, total
+
+
+def execute_upsert(
+    conn: Connection,
+    table: Table,
+    values: Dict[str, Any],
+    index_elements: List[Union[str, Column]],
+    set_: Dict[str, Any] = None,
+) -> int:
+    """
+    Execute an atomic upsert (INSERT ... ON CONFLICT DO UPDATE) for SQLite and PostgreSQL.
+    This is extendable to other dialects like MySQL (ON DUPLICATE KEY UPDATE),
+    mssql (MERGE), or oracle (UPSERT), if needed in the future.
+
+    Notice that statements are executed without an explicit commit, so the caller can manage transactions as needed.
+
+    :param conn: An open SQLAlchemy Connection (caller manages the transaction).
+    :param table: The target SQLAlchemy Table.
+    :param values: Full row values dict (column name -> value) to insert or update.
+    :param index_elements: Conflict target. List of column names or Column objects.
+    :param set_: Columns to update on conflict. If None, all columns except index_elements will be updated.
+    :return: rowcount of the executed statement.
+    """
+    str_index_elements = [
+        el if isinstance(el, str) else el.name for el in index_elements
+    ]
+
+    if set_ is None:
+        set_ = {}
+        for col in values.keys():
+            if col not in str_index_elements:
+                set_[col] = values[col]
+
+    dialect = conn.dialect.name
+    if dialect == "postgresql":
+        _insert = pg_insert
+    elif dialect == "sqlite":
+        _insert = sqlite_insert
+    else:
+        # Fallback for unsupported dialects - this will not perform an atomic upsert, so use with caution.
+        existing = conn.execute(
+            select(table).where(
+                *[table.c[el] == values[el] for el in str_index_elements]
+            )
+        ).first()
+        if existing:
+            update_stmt = (
+                table.update()
+                .where(*[table.c[el] == values[el] for el in str_index_elements])
+                .values(**set_)
+            )
+            result = conn.execute(update_stmt)
+            return result.rowcount
+        else:
+            insert_stmt = insert(table).values(**values)
+            result = conn.execute(insert_stmt)
+            return result.rowcount
+
+    stmt = (
+        _insert(table)
+        .values(**values)
+        .on_conflict_do_update(index_elements=index_elements, set_=set_)
+    )
+    return conn.execute(stmt).rowcount

--- a/autosubmit_api/repositories/experiment_details.py
+++ b/autosubmit_api/repositories/experiment_details.py
@@ -7,7 +7,7 @@ from sqlalchemy.schema import CreateTable
 
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.database import tables
-from autosubmit_api.database.common import create_autosubmit_db_engine
+from autosubmit_api.database.common import create_autosubmit_db_engine, execute_upsert
 
 
 class ExperimentDetailsModel(BaseModel):
@@ -120,25 +120,24 @@ class ExperimentDetailsSQLRepository(ExperimentDetailsRepository):
         )
 
     def upsert_details(self, exp_id, user, created, model, branch, hpc):
+        values = {
+            "exp_id": exp_id,
+            "user": user,
+            "created": created,
+            "model": model,
+            "branch": branch,
+            "hpc": hpc,
+        }
         with self.engine.connect() as conn:
-            with conn.begin():
-                try:
-                    del_stmnt = self.table.delete().where(self.table.c.exp_id == exp_id)
-                    ins_stmnt = self.table.insert().values(
-                        exp_id=exp_id,
-                        user=user,
-                        created=created,
-                        model=model,
-                        branch=branch,
-                        hpc=hpc,
-                    )
-                    conn.execute(del_stmnt)
-                    result = conn.execute(ins_stmnt)
-                    conn.commit()
-                    return result.rowcount
-                except Exception as exc:
-                    conn.rollback()
-                    raise exc
+            try:
+                rowcount = execute_upsert(
+                    conn, self.table, values, index_elements=["exp_id"]
+                )
+                conn.commit()
+            except Exception as exc:
+                conn.rollback()
+                raise exc
+        return rowcount
 
 
 def create_experiment_details_repository() -> ExperimentDetailsRepository:

--- a/autosubmit_api/repositories/experiment_status.py
+++ b/autosubmit_api/repositories/experiment_status.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from typing import Any, List
 
 from pydantic import BaseModel
-from sqlalchemy import Engine, Table, create_engine, delete, insert
+from sqlalchemy import Engine, Table, create_engine, delete
 from sqlalchemy.schema import CreateTable
 
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.database import tables
-from autosubmit_api.database.common import create_as_times_db_engine
+from autosubmit_api.database.common import create_as_times_db_engine, execute_upsert
 
 
 class ExperimentStatusModel(BaseModel):
@@ -89,26 +89,25 @@ class ExperimentStatusSQLRepository(ExperimentStatusRepository):
         )
 
     def upsert_status(self, exp_id: int, expid: str, status: str):
+        values = {
+            "exp_id": exp_id,
+            "name": expid,
+            "status": status,
+            "seconds_diff": 0,
+            "modified": datetime.now(tz=LOCAL_TZ).isoformat(
+                sep="-", timespec="seconds"
+            ),
+        }
         with self.engine.connect() as conn:
-            with conn.begin():
-                try:
-                    del_stmnt = delete(self.table).where(self.table.c.exp_id == exp_id)
-                    ins_stmnt = insert(self.table).values(
-                        exp_id=exp_id,
-                        name=expid,
-                        status=status,
-                        seconds_diff=0,
-                        modified=datetime.now(tz=LOCAL_TZ).isoformat(
-                            sep="-", timespec="seconds"
-                        ),
-                    )
-                    conn.execute(del_stmnt)
-                    result = conn.execute(ins_stmnt)
-                    conn.commit()
-                    return result.rowcount
-                except Exception as exc:
-                    conn.rollback()
-                    raise exc
+            try:
+                rowcount = execute_upsert(
+                    conn, self.table, values, index_elements=["exp_id"]
+                )
+                conn.commit()
+            except Exception as exc:
+                conn.rollback()
+                raise exc
+        return rowcount
 
     def get_only_running_expids(self):
         with self.engine.connect() as conn:

--- a/autosubmit_api/repositories/user_preferences.py
+++ b/autosubmit_api/repositories/user_preferences.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel
-from sqlalchemy import Engine, Table, create_engine, insert, update
+from sqlalchemy import Engine, Table, create_engine
 from sqlalchemy.schema import CreateTable
 
 from autosubmit_api.common.utils import LOCAL_TZ
 from autosubmit_api.config.basicConfig import APIBasicConfig
 from autosubmit_api.database import tables
-from autosubmit_api.database.common import create_as_api_db_engine
+from autosubmit_api.database.common import create_as_api_db_engine, execute_upsert
 
 
 class UserPreferencesModel(BaseModel):
@@ -69,34 +69,26 @@ class UserPreferencesSQLRepository(UserPreferencesRepository):
         with self.engine.connect() as conn:
             with conn.begin():
                 try:
-                    # Check if record exists
+                    execute_upsert(
+                        conn,
+                        self.table,
+                        {
+                            "user_id": user_id,
+                            "preferred_username": preferred_username,
+                            "created": timestamp,
+                            "modified": timestamp,
+                        },
+                        index_elements=["user_id"],
+                        set_={
+                            "preferred_username": preferred_username,
+                            "modified": timestamp,
+                        },
+                    )
+
+                    # Fetch and return the updated record (before transaction ends)
                     select_stmnt = self.table.select().where(
                         self.table.c.user_id == user_id
                     )
-                    existing = conn.execute(select_stmnt).first()
-
-                    if existing:
-                        # Update existing record
-                        update_stmnt = (
-                            update(self.table)
-                            .where(self.table.c.user_id == user_id)
-                            .values(
-                                preferred_username=preferred_username,
-                                modified=timestamp,
-                            )
-                        )
-                        conn.execute(update_stmnt)
-                    else:
-                        # Insert new record
-                        insert_stmnt = insert(self.table).values(
-                            user_id=user_id,
-                            preferred_username=preferred_username,
-                            created=timestamp,
-                            modified=timestamp,
-                        )
-                        conn.execute(insert_stmnt)
-
-                    # Fetch and return the updated record (before transaction ends)
                     result = conn.execute(select_stmnt).first()
                     conn.commit()
                 except Exception as exc:

--- a/autosubmit_api/repositories/user_preferences.py
+++ b/autosubmit_api/repositories/user_preferences.py
@@ -67,41 +67,39 @@ class UserPreferencesSQLRepository(UserPreferencesRepository):
     def upsert_preferred_username(self, user_id: str, preferred_username: str):
         timestamp = datetime.now(tz=LOCAL_TZ).isoformat(sep="-", timespec="seconds")
         with self.engine.connect() as conn:
-            with conn.begin():
-                try:
-                    execute_upsert(
-                        conn,
-                        self.table,
-                        {
-                            "user_id": user_id,
-                            "preferred_username": preferred_username,
-                            "created": timestamp,
-                            "modified": timestamp,
-                        },
-                        index_elements=["user_id"],
-                        set_={
-                            "preferred_username": preferred_username,
-                            "modified": timestamp,
-                        },
-                    )
+            try:
+                execute_upsert(
+                    conn,
+                    self.table,
+                    {
+                        "user_id": user_id,
+                        "preferred_username": preferred_username,
+                        "created": timestamp,
+                        "modified": timestamp,
+                    },
+                    index_elements=["user_id"],
+                    set_={
+                        "preferred_username": preferred_username,
+                        "modified": timestamp,
+                    },
+                )
+                conn.commit()
 
-                    # Fetch and return the updated record (before transaction ends)
-                    select_stmnt = self.table.select().where(
-                        self.table.c.user_id == user_id
-                    )
-                    result = conn.execute(select_stmnt).first()
-                    conn.commit()
-                except Exception as exc:
-                    conn.rollback()
-                    raise exc
+                # Fetch and return the updated record (before transaction ends)
+                select_stmnt = self.table.select().where(
+                    self.table.c.user_id == user_id
+                )
+                result = conn.execute(select_stmnt).first()
 
-            # Transaction is committed here automatically by conn.begin() context manager
-            return UserPreferencesModel(
-                user_id=result.user_id,
-                preferred_username=result.preferred_username,
-                created=result.created,
-                modified=result.modified,
-            )
+                return UserPreferencesModel(
+                    user_id=result.user_id,
+                    preferred_username=result.preferred_username,
+                    created=result.created,
+                    modified=result.modified,
+                )
+            except Exception as exc:
+                conn.rollback()
+                raise exc
 
 
 def create_user_preferences_repository() -> UserPreferencesRepository:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 
 import os
 import tempfile
-from typing import Tuple
+from typing import Generator, Tuple
 
 import pytest
 from fastapi.testclient import TestClient
@@ -238,17 +238,31 @@ def fixture_postgres(
     yield fixture_pg_db_copy_all[0]
 
 
-@pytest.fixture(scope="function")
-def fixture_dummy_db() -> Tuple[Engine, Table]:
-    """In-memory SQLite engine with a simple test table."""
-    engine = create_engine("sqlite:///:memory:")
+@pytest.fixture(
+    scope="function",
+    params=[
+        pytest.param("sqlite", marks=pytest.mark.sqlite),
+        pytest.param("postgres", marks=pytest.mark.postgres),
+    ],
+)
+def fixture_dummy_db(
+    request: pytest.FixtureRequest,
+) -> Generator[Tuple[Engine, Table], None, None]:
+    """SQLite (in-memory) or Postgres engine with a simple test table."""
+    if request.param == "sqlite":
+        engine = create_engine("sqlite:///:memory:")
+    else:
+        # Reuse session Postgres fixture
+        conn_url = request.getfixturevalue("fixture_setup_pg_db")
+        engine = create_engine(conn_url)
     meta = MetaData()
     test_table = Table(
-        "test_upsert",
+        "test_dummy_db",
         meta,
         Column("id", Integer, primary_key=True),
         Column("name", String, nullable=False),
         Column("value", String),
     )
     meta.create_all(engine)
-    return engine, test_table
+    yield engine, test_table
+    meta.drop_all(engine)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import Engine, create_engine
+from sqlalchemy import Column, Engine, Integer, MetaData, String, Table, create_engine
 from testcontainers.postgres import PostgresContainer
 
 from autosubmit_api import config
@@ -236,3 +236,19 @@ def fixture_postgres(
         os.path.join(fixture_pg_db_copy_all[0], ".autosubmitrc"),
     )
     yield fixture_pg_db_copy_all[0]
+
+
+@pytest.fixture(scope="function")
+def fixture_dummy_db() -> Tuple[Engine, Table]:
+    """In-memory SQLite engine with a simple test table."""
+    engine = create_engine("sqlite:///:memory:")
+    meta = MetaData()
+    test_table = Table(
+        "test_upsert",
+        meta,
+        Column("id", Integer, primary_key=True),
+        Column("name", String, nullable=False),
+        Column("value", String),
+    )
+    meta.create_all(engine)
+    return engine, test_table

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,8 @@
 import os
+from typing import Tuple
+from unittest.mock import MagicMock
 
-from sqlalchemy import select
+from sqlalchemy import Engine, Table, select
 
 from autosubmit_api.database import common, tables
 
@@ -12,7 +14,6 @@ def count_pid_lsof(pid):
 
 
 class TestDatabase:
-
     def test_open_files(self, fixture_sqlite):
         current_pid = os.getpid()
 
@@ -27,3 +28,122 @@ class TestDatabase:
             assert counter + 1 == count_pid_lsof(current_pid)
 
         assert counter == count_pid_lsof(current_pid)
+
+
+class TestExecuteUpsert:
+    def test_insert_new_row(self, fixture_dummy_db: Tuple[Engine, Table]):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            rowcount = common.execute_upsert(
+                conn, table, {"id": 1, "name": "alpha", "value": "v1"}, ["id"]
+            )
+            conn.commit()
+            assert rowcount == 1
+            row = conn.execute(select(table).where(table.c.id == 1)).first()
+        assert row.name == "alpha"
+        assert row.value == "v1"
+
+    def test_update_on_conflict(self, fixture_dummy_db: Tuple[Engine, Table]):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            common.execute_upsert(
+                conn, table, {"id": 1, "name": "alpha", "value": "v1"}, ["id"]
+            )
+            conn.commit()
+            # Upsert same id with different values
+            common.execute_upsert(
+                conn, table, {"id": 1, "name": "beta", "value": "v2"}, ["id"]
+            )
+            conn.commit()
+            row = conn.execute(select(table).where(table.c.id == 1)).first()
+        assert row.name == "beta"
+        assert row.value == "v2"
+
+    def test_update_with_explicit_set(self, fixture_dummy_db: Tuple[Engine, Table]):
+        engine, table = fixture_dummy_db
+
+        with engine.connect() as conn:
+            common.execute_upsert(
+                conn, table, {"id": 1, "name": "alpha", "value": "v1"}, ["id"]
+            )
+            conn.commit()
+            # Only update 'value', leave 'name' unchanged
+            common.execute_upsert(
+                conn,
+                table,
+                {"id": 1, "name": "ignored", "value": "v2"},
+                ["id"],
+                set_={"value": "v2"},
+            )
+            conn.commit()
+            row = conn.execute(select(table).where(table.c.id == 1)).first()
+        assert row.name == "alpha"
+        assert row.value == "v2"
+
+    def test_insert_does_not_affect_other_rows(
+        self, fixture_dummy_db: Tuple[Engine, Table]
+    ):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            common.execute_upsert(
+                conn, table, {"id": 1, "name": "alpha", "value": "v1"}, ["id"]
+            )
+            common.execute_upsert(
+                conn, table, {"id": 2, "name": "beta", "value": "v2"}, ["id"]
+            )
+            conn.commit()
+            rows = conn.execute(select(table)).all()
+        assert len(rows) == 2
+
+    def test_index_elements_as_multiple_types(
+        self, fixture_dummy_db: Tuple[Engine, Table]
+    ):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            rowcount = common.execute_upsert(
+                conn,
+                table,
+                {"id": 1, "name": "alpha", "value": "v1"},
+                [table.c.id],
+            )
+            conn.commit()
+            assert rowcount == 1
+
+            rowcount = common.execute_upsert(
+                conn,
+                table,
+                {"id": 1, "name": "alpha", "value": "v2"},
+                ["id"],
+            )
+            conn.commit()
+            assert rowcount == 1
+            row = conn.execute(select(table).where(table.c.id == 1)).first()
+            assert row.value == "v2"
+
+    def test_fallback_dialect_insert_update(
+        self, fixture_dummy_db: Tuple[Engine, Table]
+    ):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            # Mock to not use the SQLite dialect and force fallback logic
+            mock_conn = MagicMock(wraps=conn)
+            mock_conn.dialect = MagicMock(name="unsupported")
+            mock_conn.dialect.name = "unsupported"
+            rowcount = common.execute_upsert(
+                mock_conn, table, {"id": 1, "name": "alpha", "value": "v1"}, ["id"]
+            )
+            conn.commit()
+            assert rowcount == 1
+            row = conn.execute(select(table).where(table.c.id == 1)).first()
+            assert row.name == "alpha"
+            assert row.value == "v1"
+
+            # Upsert same id with different values, should perform an update
+            rowcount = common.execute_upsert(
+                mock_conn, table, {"id": 1, "name": "beta", "value": "v2"}, ["id"]
+            )
+            conn.commit()
+            assert rowcount == 1
+            row = conn.execute(select(table).where(table.c.id == 1)).first()
+            assert row.name == "beta"
+            assert row.value == "v2"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -147,3 +147,48 @@ class TestExecuteUpsert:
             row = conn.execute(select(table).where(table.c.id == 1)).first()
             assert row.name == "beta"
             assert row.value == "v2"
+
+    def test_rollback_on_exception(self, fixture_dummy_db: Tuple[Engine, Table]):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            # Attempt upsert with invalid data to trigger an exception
+            try:
+                common.execute_upsert(
+                    conn,
+                    table,
+                    {"id": None, "name": None, "value": "v1"},  # NULL invalid values
+                    ["id"],
+                )
+                raise AssertionError("Expected an exception due to NOT NULL constraint")
+            except Exception:
+                conn.rollback()
+
+            # Verify that no row was inserted
+            row = conn.execute(select(table)).first()
+            assert row is None
+
+    def test_fallback_dialect_rollback_on_exception(
+        self, fixture_dummy_db: Tuple[Engine, Table]
+    ):
+        engine, table = fixture_dummy_db
+        with engine.connect() as conn:
+            # Mock to not use the SQLite dialect and force fallback logic
+            mock_conn = MagicMock(wraps=conn)
+            mock_conn.dialect = MagicMock(name="unsupported")
+            mock_conn.dialect.name = "unsupported"
+
+            # Attempt upsert with invalid data to trigger an exception
+            try:
+                common.execute_upsert(
+                    mock_conn,
+                    table,
+                    {"id": None, "name": None, "value": "v1"},  # NULL invalid values
+                    ["id"],
+                )
+                raise AssertionError("Expected an exception due to NOT NULL constraint")
+            except Exception:
+                conn.rollback()
+
+            # Verify that no row was inserted
+            row = conn.execute(select(table)).first()
+            assert row is None


### PR DESCRIPTION
Closes #288

This PR introduces a generalized upsert function that supports native dialect from SQLite and Postgres to execute it as an atomic operation. In case, the dialect is not supported, it does a non-atomic operation as a fallback.